### PR TITLE
feat: show IP version switch for two domain targets

### DIFF
--- a/src/assets/less/components/results-table-output.less
+++ b/src/assets/less/components/results-table-output.less
@@ -362,7 +362,11 @@
 						}
 
 						&.targets {
-							width: 194px;
+							width: 100%;
+
+							@media (min-width: @screen-lg-min) {
+								width: 194px;
+							}
 
 							.results-table_row_stats_subrow_cell_value > span {
 								display: inline-block;

--- a/src/assets/less/components/results-table-output.less
+++ b/src/assets/less/components/results-table-output.less
@@ -398,9 +398,12 @@
 							}
 
 							span {
+								white-space: nowrap;
+							}
+
+							.text-ellipsis {
 								overflow: hidden;
 								text-overflow: ellipsis;
-								white-space: nowrap;
 							}
 
 							.c-placeholder-skeleton {
@@ -447,6 +450,7 @@
 							align-items: center;
 							flex-grow: 1;
 							width: 100%;
+							gap: 8px;
 							font-size: 14px;
 							font-weight: 400;
 							line-height: 20px;

--- a/src/views/components/results-table-output.html
+++ b/src/views/components/results-table-output.html
@@ -204,14 +204,14 @@
 
 									<div class="results-table_row_stats_subrow_cell ip">
 										<div class="results-table_row_stats_subrow_cell_value">
-											<span class="results-table_row_stats_subrow_cell_value_header">Resolved IP</span>
+											<span class="results-table_row_stats_subrow_cell_value_header"><span class="hidden-xs">Resolved </span>IP</span>
 											{{#if this.ipAddr}}
 												<span class="visible-lg"> <!-- We break in two lines if the value has more than 4 non-empty groups. -->
 													{{#each splitIPv6(ipAddr)}}
 														{{this}}<br>
 													{{/each}}
 												</span>
-												<span class="hidden-lg">{{this.ipAddr}}</span>
+												<span class="hidden-lg text-ellipsis">{{this.ipAddr}}</span>
 											{{elseif !this.ipAddr}}
 												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
 											{{/if}}

--- a/src/views/components/tags-input.html
+++ b/src/views/components/tags-input.html
@@ -109,9 +109,7 @@
 						this.set('ipVersion', null);
 						this.set('ipVersionDisplayed', null);
 					} else {
-						let tagsArr = this.get('tagsArr');
-
-						this.handleIpSwitchState(tagsArr[0]);
+						this.handleIpSwitchState();
 					}
 				}, { init: false });
 
@@ -139,22 +137,8 @@
 				});
 
 				// handle ip type switch
-				this.observe('tagsArr', (tagsArr) => {
-					let currIpVersionDisplayed = this.get('ipVersionDisplayed');
-
-					if (tagsArr.length > 1) {
-						this.set('ipVersion', null);
-						this.set('ipVersionDisplayed', null);
-						this.set('ipSwitchLocked', true);
-
-						if (currIpVersionDisplayed) {
-							this.set('prevIpVersionDisplayed', currIpVersionDisplayed);
-						}
-
-						return;
-					}
-
-					this.handleIpSwitchState(tagsArr[0]);
+				this.observe('tagsArr', () => {
+					this.handleIpSwitchState();
 				});
 
 				// set default value is it was passed as prop
@@ -414,18 +398,29 @@
 		handleIpTypeSwitchFocus (e, tagsBlockEl) {
 			tagsBlockEl.classList.remove('focused');
 		},
-		handleIpSwitchState (target) {
+		handleIpSwitchState () {
+			let tagsArr = this.get('tagsArr');
 			let ipv4regex = ipRegex.v4({ exact: true });
 			let ipv6regex = ipRegex.v6({ exact: true, allowBrackets: true });
 
-			if (ipv4regex.test(target)) {
+			if (tagsArr.length && tagsArr.every(target => ipv4regex.test(target))) {
 				this.set('ipVersion', null);
 				this.set('ipVersionDisplayed', IP_V4_VALUE);
 				this.set('ipSwitchLocked', true);
-			} else if (ipv6regex.test(target)) {
+			} else if (tagsArr.length && tagsArr.every(target => ipv6regex.test(target))) {
 				this.set('ipVersion', null);
 				this.set('ipVersionDisplayed', IP_V6_VALUE);
 				this.set('ipSwitchLocked', true);
+			} else if (tagsArr.some(target => ipv4regex.test(target) || ipv6regex.test(target))) {
+				// hide the IP switch in the case IP versions are mixed, or there is one domain and one IP address
+				let currIpVersionDisplayed = this.get('ipVersionDisplayed');
+				this.set('ipVersion', null);
+				this.set('ipVersionDisplayed', null);
+				this.set('ipSwitchLocked', true);
+
+				if (currIpVersionDisplayed) {
+					this.set('prevIpVersionDisplayed', currIpVersionDisplayed);
+				}
 			} else {
 				let ipVersionDisplayed = this.get('ipVersionDisplayed') || this.get('prevIpVersionDisplayed') || IP_V4_VALUE;
 


### PR DESCRIPTION
Closes #4 

When using IPv6 and two targets, the resolved IP address could not fit in the results table. For this reason, I removed the "Resolved" part of the row on mobile devices to show as much of the resolved address as possible. I also fixed a horizontal overflow. This leads to the resulting change:

Previously:

<img width="581" height="654" alt="image" src="https://github.com/user-attachments/assets/f378e534-e5a3-4462-ac1d-4cfc04d4c2dc" />

Now:

<img width="563" height="534" alt="image" src="https://github.com/user-attachments/assets/e5c9355c-59b9-4b2f-9974-ad352125c0d4" />