### PR TITLE
refactor: use variable font sources

### DIFF
--- a/src/views/r-docs.html
+++ b/src/views/r-docs.html
@@ -53,20 +53,31 @@
 
 			<!-- Maybe will be useful in Firefox at some point. -->
 			<link rel="dns-prefetch" href="https://cdn.jsdelivr.net/">
-			<link rel="dns-prefetch" href="https://fonts.gstatic.com/">
 <!--			<link rel="dns-prefetch" href="https://datum.jsdelivr.com/">-->
 
 			<link rel="preconnect" href="https://cdn.jsdelivr.net/" crossorigin="anonymous">
-			<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous">
 <!--			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">-->
-			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700&display=swap" rel="stylesheet">
-			<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" rel="stylesheet">
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">
 
 			<link rel="sitemap" href="/sitemap/index.xml" type="application/xml">
+
+			<style>
+                @font-face {
+                    font-family: 'Lexend';
+                    font-style: normal;
+                    font-weight: 100 900;
+                    src: url(https://cdn.jsdelivr.net/fontsource/fonts/lexend:vf@latest/latin-wght-normal.woff2) format('woff2-variations');
+                }
+                @font-face {
+                    font-family: 'Source Code Pro';
+                    font-style: normal;
+                    font-weight: 200 900;
+                    src: url(https://cdn.jsdelivr.net/fontsource/fonts/source-code-pro:vf@latest/latin-wght-normal.woff2) format('woff2-variations');
+                }
+			</style>
+
 			{{yield css}}
 		</head>
 

--- a/src/views/r-page.html
+++ b/src/views/r-page.html
@@ -63,21 +63,31 @@
 
 			<!-- Maybe will be useful in Firefox at some point. -->
 			<link rel="dns-prefetch" href="https://cdn.jsdelivr.net/">
-			<link rel="dns-prefetch" href="https://fonts.gstatic.com/">
 <!--			<link rel="dns-prefetch" href="https://datum.jsdelivr.com/">-->
 
 			<link rel="preconnect" href="https://cdn.jsdelivr.net/" crossorigin="anonymous">
-			<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="anonymous">
 <!--			<link rel="preconnect" href="https://datum.jsdelivr.com/" crossorigin="anonymous">-->
-			<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
 
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;600&display=swap" media="print" onload="this.media='all'">
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500&display=swap" media="print" onload="this.media='all'">
 			<link rel="stylesheet" href="{{@shared.assetsHost}}/css/app.css?v={{@shared.assetsVersion}}">
 			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" media="print" onload="this.media='all'">
-			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap" media="print" onload="this.media='all'">
 
 			<link rel="sitemap" href="/sitemap/index.xml" type="application/xml">
+
+			<style>
+                @font-face {
+                    font-family: 'Lexend';
+                    font-style: normal;
+                    font-weight: 100 900;
+                    src: url(https://cdn.jsdelivr.net/fontsource/fonts/lexend:vf@latest/latin-wght-normal.woff2) format('woff2-variations');
+                }
+                @font-face {
+                    font-family: 'Source Code Pro';
+                    font-style: normal;
+                    font-weight: 200 900;
+                    src: url(https://cdn.jsdelivr.net/fontsource/fonts/source-code-pro:vf@latest/latin-wght-normal.woff2) format('woff2-variations');
+                }
+			</style>
+
 			{{yield css}}
 		</head>
 


### PR DESCRIPTION
Finishes work from https://github.com/jsdelivr/www.jsdelivr.com/pull/740

Also remove Inter completely as it is not used anywhere.