### PR TITLE
fix: wrong initial map center on the networks page

### DIFF
--- a/src/views/components/google-maps.html
+++ b/src/views/components/google-maps.html
@@ -493,11 +493,11 @@
 				map.setCenter(position);
 				map.setZoom(minZoom);
 			} else {
-				let TEMP_MAX = 6;
+				let TEMP_MAX_ZOOM = 6;
 
 				// temp limit for zooming
-				map.setZoom(TEMP_MAX);
-				map.setOptions({ maxZoom: TEMP_MAX });
+				map.setZoom(TEMP_MAX_ZOOM);
+				map.setOptions({ maxZoom: TEMP_MAX_ZOOM });
 				map.fitBounds(bounds);
 
 				google.maps.event.addListenerOnce(map, 'idle', () => {


### PR DESCRIPTION
As discussed on Slack

Setting the zoom to its temp maximum before each bounds refit fixes the issue.