### PR TITLE
fix: broken livereload

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,8 +101,7 @@ gulp.task('less', () => {
 		.pipe(less({ relativeUrls: true, strictMath: true }))
 		.pipe(rename('app.css'))
 		.pipe(sourcemaps.write('.'))
-		.pipe(gulp.dest(`${dstAssetsDir}/css`))
-		.pipe(livereload(liveReloadOptions));
+		.pipe(gulp.dest(`${dstAssetsDir}/css`));
 });
 
 gulp.task('nuxt:less', () => {
@@ -117,8 +116,7 @@ gulp.task('nuxt:less', () => {
 		]))
 		.pipe(rename('legacy.css'))
 		.pipe(sourcemaps.write('.'))
-		.pipe(gulp.dest(`${dstAppDir}/assets/css`))
-		.pipe(livereload(liveReloadOptions));
+		.pipe(gulp.dest(`${dstAppDir}/assets/css`));
 });
 
 gulp.task('less:prod', () => {


### PR DESCRIPTION
Closes #83 

Not a problem in the JSD repo, as there need to be two concurrent calls to livereload which, while technically possible*, does not happen there. Here, it does, because of the parallel nuxt and ractive gulp tasks in `gulp.task('watch',...)`

*E.g., editing app.js and app-docs.js at the same time triggers two gulp tasks with livereload, causing the bug.