### PR TITLE
fix: do not display probe markers until clusters are ready

### DIFF
--- a/src/views/pages/_index.html
+++ b/src/views/pages/_index.html
@@ -4023,7 +4023,6 @@ rtt min/avg/max/mdev = ${minTiming}/${avgTiming}/${maxTiming}/${mdev}${showRttUn
 			markerContent.style.height = `${svgHeight}px`;
 
 			let probeMarker = new google.maps.marker.AdvancedMarkerElement({
-				map,
 				content: markerContent,
 				position: { lat: Number(lat), lng: Number(lng) },
 				zIndex: 1,


### PR DESCRIPTION
As discussed on Slack