### PR TITLE
fix: visual issues in raw output mode

### DIFF
--- a/src/assets/js/decorators/tooltip.js
+++ b/src/assets/js/decorators/tooltip.js
@@ -1,5 +1,7 @@
 const { isTouchDevice } = require('../_');
 
+let activeTooltip = null;
+
 let tooltipDecorator = (
 	node,
 	content,
@@ -19,9 +21,11 @@ let tooltipDecorator = (
 	};
 
 	let createTooltip = () => {
-		if (document.querySelector('#ractive-tooltip-instance') !== null) {
+		if (tooltip) {
 			return;
 		}
+
+		activeTooltip?.remove();
 
 		initialNodeTop = Math.round(node.getBoundingClientRect().top);
 
@@ -47,6 +51,11 @@ let tooltipDecorator = (
 
 		tooltip.id = 'ractive-tooltip-instance';
 		document.body.appendChild(tooltip);
+
+		activeTooltip = {
+			node,
+			remove: removeTooltip,
+		};
 
 		document.addEventListener('click', handleOutsideClick, true);
 		document.addEventListener('touchstart', handleOutsideClick, true);
@@ -79,6 +88,10 @@ let tooltipDecorator = (
 	};
 
 	let removeTooltip = () => {
+		if (!tooltip) {
+			return;
+		}
+
 		if (typeof rafId === 'number') {
 			cancelAnimationFrame(rafId);
 			rafId = null;
@@ -89,13 +102,14 @@ let tooltipDecorator = (
 		document.removeEventListener('click', handleOutsideClick, true);
 		document.removeEventListener('touchstart', handleOutsideClick, true);
 
-		let tooltipInstance = document.querySelector('#ractive-tooltip-instance');
-
-		if (!tooltipInstance) {
-			return;
+		if (tooltip.parentElement) {
+			tooltip.parentElement.removeChild(tooltip);
 		}
 
-		tooltipInstance.parentElement.removeChild(tooltipInstance);
+		if (activeTooltip?.node === node) {
+			activeTooltip = null;
+		}
+
 		tooltip = null;
 	};
 

--- a/src/assets/less/components/results-raw-output.less
+++ b/src/assets/less/components/results-raw-output.less
@@ -74,6 +74,7 @@
 						column-gap: 8px;
 						flex-wrap: nowrap;
 						overflow: hidden;
+						align-items: stretch;
 					}
 
 					&_arrow {
@@ -275,11 +276,23 @@
 
 						@media (max-width: @screen-xs-max) {
 							flex-grow: 1;
-							height: fit-content;
+							height: initial;
 							align-items: start;
 							flex-direction: column;
 							overflow: hidden;
 							gap: 4px;
+						}
+
+						&_logo-placeholder {
+							width: 18px !important;
+							height: 18px;
+							display: flex !important;
+							border-radius: 4px;
+							font-size: 10px;
+							color: #2d3c59;
+							border: 1px solid #e7e7ee;
+							justify-content: center;
+							align-items: center;
 						}
 
 						&_field {

--- a/src/assets/less/components/results-raw-output.less
+++ b/src/assets/less/components/results-raw-output.less
@@ -1,5 +1,11 @@
 @import "../variables.less";
 
+@keyframes raw-output-skeleton {
+	to {
+		background-position: -200% 0;
+	}
+}
+
 .c-gp-results-raw-output {
 	display: flex;
 	flex-direction: column;
@@ -293,6 +299,22 @@
 							border: 1px solid #e7e7ee;
 							justify-content: center;
 							align-items: center;
+						}
+
+						&_loading-placeholder {
+							display: block;
+							width: 77px !important;
+							height: 18px;
+							border-radius: 4px;
+							background: linear-gradient(90deg, #f1f1f4 25%, #e7e7ee 50%, #f1f1f4 75%);
+							background-size: 200% 100%;
+							animation: raw-output-skeleton 1.2s linear infinite;
+
+							@media (max-width: @screen-xs-max) {
+								height: 20px;
+								margin: 2px 0;
+								justify-self: start !important;
+							}
 						}
 
 						&_field {

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -2,7 +2,7 @@
 <link rel="ractive" href="./dot-loader.html" name="c-dot-loader">
 
 <div class="c-gp-results-raw-output">
-	<div class="c-gp-results-raw-output_list {{#if testInProgress}}round-bottom{{/if}}" on-scroll="@this.hideSetLocationButton()">
+	<div class="c-gp-results-raw-output_list {{#if testInProgress}}round-bottom{{/if}}" on-scroll="@this.hideSetLocationButton(@event)">
 		{{#each preparedTestResults}}
 			<div class="c-gp-results-raw-output_list_item item-id-{{this.clientSideId}}"
 				{{#if showSetLocationButton}}
@@ -390,7 +390,16 @@
 			if (!this.get('showSetLocationButton')) { return; }
 
 			if (this.get('justFocusedItem')) {
-				this.set('justFocusedItem', false);
+				if (event?.type !== 'scroll') {
+					this.set('justFocusedItem', false);
+				}
+
+				return;
+			}
+
+			if (event?.type === 'scroll') {
+				this.set('itemFocused', false);
+				this.set('floatingSetLocationButton.visible', false);
 				return;
 			}
 

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -37,6 +37,10 @@
 										height="18"
 										alt=""
 										src="{{@shared.logoHost}}/{{@this.getNetworkDomainNameByAsn(this.asn)}}?v={{@shared.assetsVersion}}&padding=0">
+								{{else}}
+									<span class="c-gp-results-raw-output_list_item_header_info_entity_logo-placeholder">
+										{{this.network[0]}}
+									</span>
 								{{/if}}
 								<span>{{this.network}}</span>
 							</span>
@@ -53,24 +57,32 @@
 									<span>{{this.statsPerTarget[activeTargetIdx].ipAddr}}</span>
 								</span>
 
-								<span class="c-gp-results-raw-output_list_item_header_info_entity_field">
-									{{#if @this.isAnycastIp(this.statsPerTarget[activeTargetIdx].ipAddr)}}
-										<img width="22" height="16" alt="" src="{{@shared.assetsHost}}/img/anycast.svg">
-										Anycast
-									{{elseif @this.getIpLocationLabel(this.statsPerTarget[activeTargetIdx].ipAddr)}}
-										{{#if @this.getIpLocationCountryCode(this.statsPerTarget[activeTargetIdx].ipAddr)}}
-											<img width="21" height="14" alt="" src="https://cdn.jsdelivr.net/npm/country-flag-icons@1.5.5/3x2/{{@this.getIpLocationCountryCode(this.statsPerTarget[activeTargetIdx].ipAddr)}}.svg">
-										{{/if}}
-										<span>{{@this.getIpLocationLabel(this.statsPerTarget[activeTargetIdx].ipAddr)}}</span>
-									{{/if}}
-								</span>
-
-								{{#if @this.shouldRenderTargetNetwork(this.statsPerTarget[activeTargetIdx].ipAddr)}}
+								{{#if @this.isAnycastIp(this.statsPerTarget[activeTargetIdx].ipAddr) || @this.getIpLocationLabel(this.statsPerTarget[activeTargetIdx].ipAddr)}}
 									<span class="c-gp-results-raw-output_list_item_header_info_entity_field">
-										<img width="18"
-											height="18"
-											src="{{@shared.logoHost}}/{{@this.getNetworkDomainNameByIp(this.statsPerTarget[activeTargetIdx].ipAddr)}}?v={{@shared.assetsVersion}}&padding=0"
-											alt="{{@this.getNetworkName(this.statsPerTarget[activeTargetIdx].ipAddr)}} logo">
+										{{#if @this.isAnycastIp(this.statsPerTarget[activeTargetIdx].ipAddr)}}
+											<img width="22" height="16" alt="" src="{{@shared.assetsHost}}/img/anycast.svg">
+											Anycast
+										{{else}}
+											{{#if @this.getIpLocationCountryCode(this.statsPerTarget[activeTargetIdx].ipAddr)}}
+												<img width="21" height="14" alt="" src="https://cdn.jsdelivr.net/npm/country-flag-icons@1.5.5/3x2/{{@this.getIpLocationCountryCode(this.statsPerTarget[activeTargetIdx].ipAddr)}}.svg">
+											{{/if}}
+											<span>{{@this.getIpLocationLabel(this.statsPerTarget[activeTargetIdx].ipAddr)}}</span>
+										{{/if}}
+									</span>
+								{{/if}}
+
+								{{#if @this.getNetworkName(this.statsPerTarget[activeTargetIdx].ipAddr)}}
+									<span class="c-gp-results-raw-output_list_item_header_info_entity_field">
+										{{#if @this.getNetworkDomainNameByIp(this.statsPerTarget[activeTargetIdx].ipAddr)}}
+											<img width="18"
+												height="18"
+												src="{{@shared.logoHost}}/{{@this.getNetworkDomainNameByIp(this.statsPerTarget[activeTargetIdx].ipAddr)}}?v={{@shared.assetsVersion}}&padding=0"
+												alt="{{@this.getNetworkName(this.statsPerTarget[activeTargetIdx].ipAddr)}} logo">
+										{{else}}
+											<span class="c-gp-results-raw-output_list_item_header_info_entity_logo-placeholder">
+												{{@this.getNetworkName(this.statsPerTarget[activeTargetIdx].ipAddr)[0]}}
+											</span>
+										{{/if}}
 										<span>{{@this.getNetworkName(this.statsPerTarget[activeTargetIdx].ipAddr)}}</span>
 									</span>
 								{{/if}}
@@ -78,38 +90,39 @@
 						{{/if}}
 					</div>
 
-						<div class="c-gp-results-raw-output_list_item_header_metrics-controls">
-							{{#if !this.statsPerTarget[activeTargetIdx].rawOutput}}
-								<c-dot-loader></c-dot-loader>
-							{{else}}
-								<div class="c-gp-results-raw-output_list_item_header_metrics-controls_metrics">
-									{{#if _.getGpTargetTiming(this.statsPerTarget[activeTargetIdx])}}
+					<div class="c-gp-results-raw-output_list_item_header_metrics-controls">
+						{{#if !this.statsPerTarget[activeTargetIdx].rawOutput}}
+							<c-dot-loader></c-dot-loader>
+						{{else}}
+							<div class="c-gp-results-raw-output_list_item_header_metrics-controls_metrics">
+								{{#if _.getGpTargetTiming(this.statsPerTarget[activeTargetIdx])}}
+									<span class="c-gp-results-raw-output_list_item_header_metrics-controls_metric">
+										Time
+										<b>
+											{{_.getGpTargetTiming(this.statsPerTarget[activeTargetIdx])}}
+										</b>
+									</span>
+								{{/if}}
+
+								{{#unless this.statsPerTarget[activeTargetIdx].isFailed || this.statsPerTarget[activeTargetIdx].avgTiming === PROBE_STATUS_OFFLINE}}
+									{{#each this.statsPerTarget[activeTargetIdx].extraValues}}
 										<span class="c-gp-results-raw-output_list_item_header_metrics-controls_metric">
-											Time
-											<b>
-												{{_.getGpTargetTiming(this.statsPerTarget[activeTargetIdx])}}
-											</b>
+											{{this.text}}
+											<b>{{this.value}}{{this.units}}</b>
 										</span>
-									{{/if}}
+									{{/each}}
+								{{/unless}}
+							</div>
 
-									{{#unless this.statsPerTarget[activeTargetIdx].isFailed || this.statsPerTarget[activeTargetIdx].avgTiming === PROBE_STATUS_OFFLINE}}
-										{{#each this.statsPerTarget[activeTargetIdx].extraValues}}
-											<span class="c-gp-results-raw-output_list_item_header_metrics-controls_metric">
-												{{this.text}}
-												<b>{{this.value}}{{this.units}}</b>
-											</span>
-										{{/each}}
-									{{/unless}}
-								</div>
-
-								<button on-click="@this.hideShowTestResult(this.clientSideId)"
-									role="button"
-									aria-label="{{#if hiddenTestResults[activeTargetIdx].includes(this.clientSideId)}}Expand{{else}}Collapse{{/if}} output"
-									class="c-gp-results-raw-output_list_item_header_metrics-controls_dropdown">
-									<i class="fa fa-chevron-{{#if hiddenTestResults[activeTargetIdx].includes(this.clientSideId)}}down{{else}}up{{/if}}" aria-hidden="true"/>
-								</button>
-							{{/if}}
-						</div>
+							<button on-click="@this.hideShowTestResult(this.clientSideId)"
+								role="button"
+								aria-label="{{#if hiddenTestResults[activeTargetIdx].includes(this.clientSideId)}}Expand{{else}}Collapse{{/if}} output"
+								class="c-gp-results-raw-output_list_item_header_metrics-controls_dropdown">
+								<i class="fa fa-chevron-{{#if hiddenTestResults[activeTargetIdx].includes(this.clientSideId)}}down{{else}}up{{/if}}" aria-hidden="true"/>
+							</button>
+						{{/if}}
+					</div>
+				</div>
 
 				{{#if this.statsPerTarget[activeTargetIdx].rawOutput}}
 					<div class="c-gp-results-raw-output_list_item_output">
@@ -595,7 +608,7 @@
 			let locationText = [ result?.city, result?.state, result?.country ].filter(Boolean).join(', ');
 			let networkText = result?.network || '';
 			let fieldsTextWidth = this.measureHeaderInfoTextWidth(asnText) + this.measureHeaderInfoTextWidth(locationText) + this.measureHeaderInfoTextWidth(networkText);
-			let iconWidths = 16 + 24 + 16;
+			let iconWidths = 16 + 21 + 18;
 			let textIconGaps = 6 * 3;
 			let fieldsGap = 16 * 2;
 			let entityHorizontalPadding = 8 * 2;
@@ -612,15 +625,17 @@
 
 			let ipTextWidth = this.measureHeaderInfoTextWidth(ipAddr);
 			let locationLabel = this.isAnycastIp(ipAddr) ? 'Anycast' : this.getIpLocationLabel(ipAddr) || '';
-			let locationTextWidth = this.measureHeaderInfoTextWidth(locationLabel);
-			let networkName = this.shouldRenderTargetNetwork(ipAddr) ? this.getNetworkName(ipAddr) || '' : '';
+			let hasLocationField = !!locationLabel;
+			let locationTextWidth = hasLocationField ? this.measureHeaderInfoTextWidth(locationLabel) : 0;
+			let networkName = this.getNetworkName(ipAddr) || '';
 			let networkTextWidth = this.measureHeaderInfoTextWidth(networkName);
-			let fieldCount = 2 + (networkName ? 1 : 0);
+			let fieldCount = 1 + (hasLocationField ? 1 : 0) + (networkName ? 1 : 0);
 			let hasLocationIcon = this.isAnycastIp(ipAddr) || !!this.getIpLocationCountryCode(ipAddr);
+			let locationIconWidth = hasLocationField ? this.isAnycastIp(ipAddr) ? 22 : this.getIpLocationCountryCode(ipAddr) ? 21 : 0 : 0;
 			let iconCount = 1 + (hasLocationIcon ? 1 : 0) + (networkName ? 1 : 0);
-			let iconWidths = 16 + (this.isAnycastIp(ipAddr) ? 22 : this.getIpLocationCountryCode(ipAddr) ? 21 : 0) + (networkName ? 18 : 0);
+			let iconWidths = 16 + locationIconWidth + (networkName ? 18 : 0);
 			let textIconGaps = iconCount * 6;
-			let fieldsGap = 16 * (fieldCount - 1);
+			let fieldsGap = 16 * Math.max(fieldCount - 1, 0);
 			let entityHorizontalPadding = 8 * 2;
 
 			return ipTextWidth + locationTextWidth + networkTextWidth + iconWidths + textIconGaps + fieldsGap + entityHorizontalPadding;

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -69,6 +69,10 @@
 											<span>{{@this.getIpLocationLabel(this.statsPerTarget[activeTargetIdx].ipAddr)}}</span>
 										{{/if}}
 									</span>
+								{{elseif @this.isTargetNetworkInfoLoading(this.statsPerTarget[activeTargetIdx].ipAddr)}}
+									<span class="c-gp-results-raw-output_list_item_header_info_entity_field">
+										<span class="c-gp-results-raw-output_list_item_header_info_entity_loading-placeholder"></span>
+									</span>
 								{{/if}}
 
 								{{#if @this.getNetworkName(this.statsPerTarget[activeTargetIdx].ipAddr)}}
@@ -84,6 +88,10 @@
 											</span>
 										{{/if}}
 										<span>{{@this.getNetworkName(this.statsPerTarget[activeTargetIdx].ipAddr)}}</span>
+									</span>
+								{{elseif @this.isTargetNetworkInfoLoading(this.statsPerTarget[activeTargetIdx].ipAddr)}}
+									<span class="c-gp-results-raw-output_list_item_header_info_entity_field">
+										<span class="c-gp-results-raw-output_list_item_header_info_entity_loading-placeholder"></span>
 									</span>
 								{{/if}}
 							</div>
@@ -201,6 +209,7 @@
 				},
 				networkDomainNamesByIp: Object.create(null),
 				networkDomainNamesByAsn: Object.create(null),
+				loadingNetworkIps: Object.create(null),
 				PROBE_STATUS_FAILED,
 				PROBE_STATUS_OFFLINE,
 				pendingDomainLookups: new Set(),
@@ -629,7 +638,11 @@
 			let locationTextWidth = hasLocationField ? this.measureHeaderInfoTextWidth(locationLabel) : 0;
 			let networkName = this.getNetworkName(ipAddr) || '';
 			let networkTextWidth = this.measureHeaderInfoTextWidth(networkName);
-			let fieldCount = 1 + (hasLocationField ? 1 : 0) + (networkName ? 1 : 0);
+			let isNetworkInfoLoading = this.isTargetNetworkInfoLoading(ipAddr);
+			let hasLocationPlaceholder = !hasLocationField && isNetworkInfoLoading;
+			let hasNetworkPlaceholder = !networkName && isNetworkInfoLoading;
+			let loadingPlaceholderWidth = 77 * ((hasLocationPlaceholder ? 1 : 0) + (hasNetworkPlaceholder ? 1 : 0));
+			let fieldCount = 1 + (hasLocationField ? 1 : 0) + (networkName ? 1 : 0) + (hasLocationPlaceholder ? 1 : 0) + (hasNetworkPlaceholder ? 1 : 0);
 			let hasLocationIcon = this.isAnycastIp(ipAddr) || !!this.getIpLocationCountryCode(ipAddr);
 			let locationIconWidth = hasLocationField ? this.isAnycastIp(ipAddr) ? 22 : this.getIpLocationCountryCode(ipAddr) ? 21 : 0 : 0;
 			let iconCount = 1 + (hasLocationIcon ? 1 : 0) + (networkName ? 1 : 0);
@@ -638,7 +651,7 @@
 			let fieldsGap = 16 * Math.max(fieldCount - 1, 0);
 			let entityHorizontalPadding = 8 * 2;
 
-			return ipTextWidth + locationTextWidth + networkTextWidth + iconWidths + textIconGaps + fieldsGap + entityHorizontalPadding;
+			return ipTextWidth + locationTextWidth + networkTextWidth + loadingPlaceholderWidth + iconWidths + textIconGaps + fieldsGap + entityHorizontalPadding;
 		},
 		resetHeaderInfoEntityWidthCache () {
 			this.set('headerInfoEntityWidthsByKey', Object.create(null));
@@ -741,6 +754,11 @@
 
 			pendingDomainLookups.add(ipAddr);
 
+			this.set(`loadingNetworkIps.${Ractive.escapeKey(ipAddr)}`, true);
+
+			this.resetHeaderInfoEntityWidthCache();
+			this.recalculateHeaderInfoLayoutStates();
+
 			http.getNetworkFromIP(ipAddr)
 				.then((res) => {
 					this.set('showingNetworkLogos', this.get('showingNetworkLogos') || !!res?.domain);
@@ -758,6 +776,7 @@
 				})
 				.finally(() => {
 					pendingDomainLookups.delete(ipAddr);
+					this.set(`loadingNetworkIps.${Ractive.escapeKey(ipAddr)}`, false);
 					this.resetHeaderInfoEntityWidthCache();
 					this.recalculateHeaderInfoLayoutStates();
 				});
@@ -810,6 +829,9 @@
 		getNetworkName (ipAddr) {
 			let network = this.getNetworkDataByIp(ipAddr);
 			return network?.name || network?.domain || null;
+		},
+		isTargetNetworkInfoLoading (ipAddr) {
+			return !!this.get('loadingNetworkIps')[ipAddr];
 		},
 		getLocationByIp (ipAddr) {
 			return this.getNetworkDataByIp(ipAddr)?.location || null;

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -225,6 +225,7 @@
 					visible: false,
 					top: 0,
 					left: 0,
+					clientSideId: null,
 					probeData: null,
 				},
 				showSetLocationButton: true,
@@ -263,6 +264,10 @@
 
 					this.recalculateHeaderInfoLayoutStates({
 						allowShrink: this.shouldAllowResultsBlockShrink(),
+					});
+
+					requestAnimationFrame(() => {
+						this.hideSetLocationButtonIfMoved();
 					});
 				}, { deep: true, defer: true });
 
@@ -348,10 +353,38 @@
 
 			this.set('floatingSetLocationButton', {
 				visible: true,
+				clientSideId,
 				probeData,
 				top: relativeTop + nodeHeaderHeight / 2 - 13,
 				left: relativeLeft - 26,
 			});
+		},
+		hideSetLocationButtonIfMoved () {
+			let floatingSetLocationButton = this.get('floatingSetLocationButton');
+
+			if (!floatingSetLocationButton.visible) {
+				return;
+			}
+
+			let node = this.find(`.item-id-${floatingSetLocationButton.clientSideId}`);
+			let nodeHeader = node?.querySelector('.c-gp-results-raw-output_list_item_header_info');
+			let container = this.find('.c-gp-results-raw-output');
+
+			if (!node || !nodeHeader || !container) {
+				this.set('itemFocused', false);
+				this.set('floatingSetLocationButton.visible', false);
+				return;
+			}
+
+			let nodeRect = node.getBoundingClientRect();
+			let containerRect = container.getBoundingClientRect();
+			let top = nodeRect.top - containerRect.top + nodeHeader.getBoundingClientRect().height / 2 - 13;
+			let left = nodeRect.left - containerRect.left - 26;
+
+			if (top !== floatingSetLocationButton.top || left !== floatingSetLocationButton.left) {
+				this.set('itemFocused', false);
+				this.set('floatingSetLocationButton.visible', false);
+			}
 		},
 		hideSetLocationButton (event) {
 			if (!this.get('showSetLocationButton')) { return; }

--- a/src/views/components/results-table-output.html
+++ b/src/views/components/results-table-output.html
@@ -1,7 +1,7 @@
 <link rel="ractive" href="../components/placeholder-skeleton.html" name="c-placeholder-skeleton">
 
 <div class="c-gp-results-table-output">
-	<div class="results-table-wrapper" on-scroll="@this.hideSetLocationButton()">
+	<div class="results-table-wrapper" on-scroll="@this.hideSetLocationButton(@event)">
 		<div class="results-table {{#if targetsCnt === 1}}single-target{{/if}}">
 			<div class="results-table_header">
 				<button class="results-table_header_cell location" on-click="@this.onSortClick('location')">
@@ -387,7 +387,16 @@
 		},
 		hideSetLocationButton (event) {
 			if (this.get('justFocusedItem')) {
-				this.set('justFocusedItem', false);
+				if (event?.type !== 'scroll') {
+					this.set('justFocusedItem', false);
+				}
+
+				return;
+			}
+
+			if (event?.type === 'scroll') {
+				this.set('floatingSetLocationButton.visible', false);
+				this.set('itemFocused', false);
 				return;
 			}
 


### PR DESCRIPTION
Closes #165 

1) Tooltip decorator now only removes it's own tooltip node (not just found any on the page)
2) Reserve space for logos when loading (via a placeholder)
3) Add loading skeletons while fetching target network information