### PR TITLE
perf: optimize raw results header overflow cache

### DIFF
--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -211,7 +211,7 @@
 					1: [],
 				},
 				networkDataByIp: Object.create(null),
-				logoErrors: Object.create(null),
+				logoErrors: new Set(),
 				networkLookupsActive: false,
 				PROBE_STATUS_FAILED,
 				PROBE_STATUS_OFFLINE,
@@ -222,8 +222,8 @@
 				headerInfoCharWidths: null,
 				headerInfoFallbackCharWidth: 7,
 				headerInfoListWidth: 0,
-				headerInfoOverflowByResultId: Object.create(null),
-				headerInfoEntityWidthsByKey: Object.create(null),
+				headerInfoOverflowByResultId: new Set(),
+				headerInfoEntityWidthsByKey: new Map(),
 				floatingSetLocationButton: {
 					visible: false,
 					top: 0,
@@ -736,7 +736,7 @@
 		},
 		resetHeaderInfoEntityWidthCache (ipAddresses = null) {
 			if (ipAddresses === null) {
-				this.set('headerInfoEntityWidthsByKey', Object.create(null));
+				this.set('headerInfoEntityWidthsByKey', new Map());
 				return;
 			}
 
@@ -747,19 +747,20 @@
 			let activeTargetIdx = this.get('activeTargetIdx');
 			let ipAddressSet = new Set(ipAddresses);
 			let preparedTestResults = this.get('preparedTestResults') || [];
-			let headerInfoEntityWidthsByKey = this.get('headerInfoEntityWidthsByKey');
+			let headerInfoEntityWidthsByKey = new Map(this.get('headerInfoEntityWidthsByKey'));
 
 			preparedTestResults.forEach((result) => {
 				let ipAddr = result?.statsPerTarget?.[activeTargetIdx]?.ipAddr;
 
 				if (ipAddressSet.has(ipAddr)) {
-					delete headerInfoEntityWidthsByKey[this.getHeaderInfoEntityWidthCacheKey(result)];
+					headerInfoEntityWidthsByKey.delete(this.getHeaderInfoEntityWidthCacheKey(result));
 				}
 			});
 		},
 		getHeaderInfoEntityWidths (result) {
 			let cacheKey = this.getHeaderInfoEntityWidthCacheKey(result);
-			let cached = this.get('headerInfoEntityWidthsByKey')[cacheKey];
+			let headerInfoEntityWidthsByKey = this.get('headerInfoEntityWidthsByKey');
+			let cached = headerInfoEntityWidthsByKey.get(cacheKey);
 
 			if (cached) {
 				return cached;
@@ -769,10 +770,7 @@
 			let source = target ? this.getHeaderInfoSourceEntityWidth(result) : 0;
 			let widths = { target, source };
 
-			this.set('headerInfoEntityWidthsByKey', {
-				...this.get('headerInfoEntityWidthsByKey'),
-				[cacheKey]: widths,
-			});
+			headerInfoEntityWidthsByKey.set(cacheKey, widths);
 
 			return widths;
 		},
@@ -782,12 +780,12 @@
 			let preparedTestResults = this.get('preparedTestResults') || [];
 			let previousListWidth = this.get('headerInfoListWidth') || 0;
 			let headerInfoEntityWidthsByKey = this.get('headerInfoEntityWidthsByKey');
-			let shouldRecalculateCachedOverflow = listWidth !== previousListWidth || Object.keys(headerInfoEntityWidthsByKey).length === 0;
+			let shouldRecalculateCachedOverflow = listWidth !== previousListWidth || headerInfoEntityWidthsByKey.size === 0;
 
-			let previousOverflowByResultId = this.get('headerInfoOverflowByResultId') || Object.create(null);
+			let previousOverflowByResultId = this.get('headerInfoOverflowByResultId') || new Set();
 			let overflowByResultId = shouldRecalculateCachedOverflow
-				? Object.create(null)
-				: { ...previousOverflowByResultId };
+				? new Set()
+				: new Set(previousOverflowByResultId);
 
 			let didUpdateOverflow = shouldRecalculateCachedOverflow;
 
@@ -799,13 +797,13 @@
 
 			preparedTestResults.forEach((result) => {
 				let resultId = result.clientSideId;
-				let wasWidthCached = !!headerInfoEntityWidthsByKey[this.getHeaderInfoEntityWidthCacheKey(result)];
+				let wasWidthCached = headerInfoEntityWidthsByKey.has(this.getHeaderInfoEntityWidthCacheKey(result));
 				let widths = this.getHeaderInfoEntityWidths(result);
 				let targetEntityWidth = widths.target;
 
 				if (!targetEntityWidth) {
-					if (Object.hasOwn(overflowByResultId, resultId)) {
-						delete overflowByResultId[resultId];
+					if (overflowByResultId.has(resultId)) {
+						overflowByResultId.delete(resultId);
 						didUpdateOverflow = true;
 					}
 
@@ -819,11 +817,15 @@
 				let sourceEntityWidth = widths.source;
 				let shouldUseOverflowLayout = sourceEntityWidth > availableHalfWidth || targetEntityWidth > availableHalfWidth;
 
-				if (overflowByResultId[resultId] !== shouldUseOverflowLayout) {
+				if (overflowByResultId.has(resultId) !== shouldUseOverflowLayout) {
 					didUpdateOverflow = true;
 				}
 
-				overflowByResultId[resultId] = shouldUseOverflowLayout;
+				if (shouldUseOverflowLayout) {
+					overflowByResultId.add(resultId);
+				} else {
+					overflowByResultId.delete(resultId);
+				}
 			});
 
 			if (didUpdateOverflow) {
@@ -835,8 +837,8 @@
 			}
 		},
 		shouldUseOverflowLayout (result) {
-			let overflowByResultId = this.get('headerInfoOverflowByResultId') || {};
-			return !!overflowByResultId[result?.clientSideId];
+			let overflowByResultId = this.get('headerInfoOverflowByResultId') || new Set();
+			return overflowByResultId.has(result?.clientSideId);
 		},
 		recalculateHeaderInfoLayoutStatesAfterNetworkLookup () {
 			if (this.get('pendingNetworkLookups').size > 0) {
@@ -857,8 +859,8 @@
 				return;
 			}
 
-			this.pendingNetworkDataUpdatesByIp = this.pendingNetworkDataUpdatesByIp || Object.create(null);
-			this.pendingNetworkDataUpdatesByIp[ipAddr] = networkData;
+			this.pendingNetworkDataUpdatesByIp = this.pendingNetworkDataUpdatesByIp || new Map();
+			this.pendingNetworkDataUpdatesByIp.set(ipAddr, networkData);
 			this.scheduleNetworkDataUpdatesFlush();
 		},
 		scheduleNetworkDataUpdatesFlush () {
@@ -881,23 +883,23 @@
 			}, 500);
 		},
 		flushNetworkDataUpdates () {
-			let networkDataUpdatesByIp = this.pendingNetworkDataUpdatesByIp || Object.create(null);
-			let hasIpUpdates = Object.keys(networkDataUpdatesByIp).length > 0;
+			let networkDataUpdatesByIp = this.pendingNetworkDataUpdatesByIp || new Map();
+			let hasIpUpdates = networkDataUpdatesByIp.size > 0;
 
 			if (hasIpUpdates) {
 				this.set('networkDataByIp', {
 					...this.get('networkDataByIp'),
-					...networkDataUpdatesByIp,
+					...Object.fromEntries(networkDataUpdatesByIp),
 				});
 
-				this.pendingNetworkDataUpdatesByIp = Object.create(null);
+				this.pendingNetworkDataUpdatesByIp = new Map();
 			}
 
 			if (hasIpUpdates) {
-				this.set('showingNetworkLogos', this.get('showingNetworkLogos') || Object.values(networkDataUpdatesByIp).some(networkData => !!networkData?.asn));
+				this.set('showingNetworkLogos', this.get('showingNetworkLogos') || Array.from(networkDataUpdatesByIp.values()).some(networkData => !!networkData?.asn));
 			}
 
-			return Object.keys(networkDataUpdatesByIp);
+			return Array.from(networkDataUpdatesByIp.keys());
 		},
 		populateNetworkData () {
 			let preparedTestResults = this.get('preparedTestResults') || [];
@@ -988,13 +990,11 @@
 			return this.getNetworkAsnByIp(ipAddr) && this.getNetworkName(ipAddr);
 		},
 		logoError (logoKey) {
-			return !!this.get('logoErrors')[logoKey];
+			return this.get('logoErrors').has(logoKey);
 		},
 		setLogoError (logoKey) {
-			this.set('logoErrors', {
-				...this.get('logoErrors'),
-				[logoKey]: true,
-			});
+			this.get('logoErrors').add(logoKey);
+			this.update('logoErrors');
 		},
 		// --- Other functions ---
 		getStatusColor (targetStats) {

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -721,12 +721,34 @@
 
 			return ipTextWidth + locationTextWidth + networkTextWidth + loadingPlaceholderWidth + iconWidths + textIconGaps + fieldsGap + entityHorizontalPadding;
 		},
-		resetHeaderInfoEntityWidthCache () {
-			this.set('headerInfoEntityWidthsByKey', Object.create(null));
+		getHeaderInfoEntityWidthCacheKey (result, activeTargetIdx = this.get('activeTargetIdx')) {
+			return `${activeTargetIdx}:${result?.clientSideId ?? ''}`;
+		},
+		resetHeaderInfoEntityWidthCache (ipAddresses = null) {
+			if (ipAddresses === null) {
+				this.set('headerInfoEntityWidthsByKey', Object.create(null));
+				return;
+			}
+
+			if (ipAddresses.length === 0) {
+				return;
+			}
+
+			let activeTargetIdx = this.get('activeTargetIdx');
+			let ipAddressSet = new Set(ipAddresses);
+			let preparedTestResults = this.get('preparedTestResults') || [];
+			let headerInfoEntityWidthsByKey = this.get('headerInfoEntityWidthsByKey');
+
+			preparedTestResults.forEach((result) => {
+				let ipAddr = result?.statsPerTarget?.[activeTargetIdx]?.ipAddr;
+
+				if (ipAddressSet.has(ipAddr)) {
+					delete headerInfoEntityWidthsByKey[this.getHeaderInfoEntityWidthCacheKey(result)];
+				}
+			});
 		},
 		getHeaderInfoEntityWidths (result) {
-			let activeTargetIdx = this.get('activeTargetIdx');
-			let cacheKey = `${activeTargetIdx}:${result?.clientSideId ?? ''}`;
+			let cacheKey = this.getHeaderInfoEntityWidthCacheKey(result);
 			let cached = this.get('headerInfoEntityWidthsByKey')[cacheKey];
 
 			if (cached) {
@@ -756,25 +778,55 @@
 			let listEl = this.find('.c-gp-results-raw-output_list');
 			let listWidth = listEl?.getBoundingClientRect?.().width || 0;
 			let preparedTestResults = this.get('preparedTestResults') || [];
-			let overflowByResultId = Object.create(null);
+			let previousListWidth = this.get('headerInfoListWidth') || 0;
+			let headerInfoEntityWidthsByKey = this.get('headerInfoEntityWidthsByKey');
+			let shouldRecalculateCachedOverflow = listWidth !== previousListWidth || Object.keys(headerInfoEntityWidthsByKey).length === 0;
 
-			this.set('headerInfoListWidth', listWidth);
+			let previousOverflowByResultId = this.get('headerInfoOverflowByResultId') || Object.create(null);
+			let overflowByResultId = shouldRecalculateCachedOverflow
+				? Object.create(null)
+				: { ...previousOverflowByResultId };
+
+			let didUpdateOverflow = shouldRecalculateCachedOverflow;
+
+			if (shouldRecalculateCachedOverflow) {
+				this.set('headerInfoListWidth', listWidth);
+			}
+
 			let availableHalfWidth = this.getHeaderInfoAvailableHalfWidth();
 
 			preparedTestResults.forEach((result) => {
+				let resultId = result.clientSideId;
+				let wasWidthCached = !!headerInfoEntityWidthsByKey[this.getHeaderInfoEntityWidthCacheKey(result)];
 				let widths = this.getHeaderInfoEntityWidths(result);
 				let targetEntityWidth = widths.target;
 
 				if (!targetEntityWidth) {
+					if (Object.hasOwn(overflowByResultId, resultId)) {
+						delete overflowByResultId[resultId];
+						didUpdateOverflow = true;
+					}
+
+					return;
+				}
+
+				if (wasWidthCached && !shouldRecalculateCachedOverflow) {
 					return;
 				}
 
 				let sourceEntityWidth = widths.source;
+				let shouldUseOverflowLayout = sourceEntityWidth > availableHalfWidth || targetEntityWidth > availableHalfWidth;
 
-				overflowByResultId[result.clientSideId] = sourceEntityWidth > availableHalfWidth || targetEntityWidth > availableHalfWidth;
+				if (overflowByResultId[resultId] !== shouldUseOverflowLayout) {
+					didUpdateOverflow = true;
+				}
+
+				overflowByResultId[resultId] = shouldUseOverflowLayout;
 			});
 
-			this.set('headerInfoOverflowByResultId', overflowByResultId);
+			if (didUpdateOverflow) {
+				this.set('headerInfoOverflowByResultId', overflowByResultId);
+			}
 
 			if (updateHeight) {
 				this.setResultsBlockHeight({ allowShrink });
@@ -794,8 +846,7 @@
 				this.pendingNetworkDataUpdatesFlushTimeout = null;
 			}
 
-			this.flushNetworkDataUpdates();
-			this.resetHeaderInfoEntityWidthCache();
+			this.resetHeaderInfoEntityWidthCache(this.flushNetworkDataUpdates());
 			this.recalculateHeaderInfoLayoutStates({ allowShrink: false });
 		},
 		// --- Fetching and caching network data + related getters ---
@@ -823,8 +874,7 @@
 				}
 
 				this.pendingNetworkDataUpdatesFlushTimeout = null;
-				this.flushNetworkDataUpdates();
-				this.resetHeaderInfoEntityWidthCache();
+				this.resetHeaderInfoEntityWidthCache(this.flushNetworkDataUpdates());
 				this.recalculateHeaderInfoLayoutStates({ allowShrink: false });
 			}, 500);
 		},
@@ -844,6 +894,8 @@
 			if (hasIpUpdates) {
 				this.set('showingNetworkLogos', this.get('showingNetworkLogos') || Object.values(networkDataUpdatesByIp).some(networkData => !!networkData?.asn));
 			}
+
+			return Object.keys(networkDataUpdatesByIp);
 		},
 		populateNetworkData () {
 			let preparedTestResults = this.get('preparedTestResults') || [];

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -238,18 +238,13 @@
 		},
 		computed: {
 			responseBodyCharsPerLine () {
-				let contentWidth = 0;
+				let listWidth = this.get('headerInfoListWidth') || 0;
 				let outputHorizontalPadding = 32 * 2;
+				let outputListMargin = 24 * 2;
 
-				try {
-					let listEl = this.find('.c-gp-results-raw-output_list');
-					let listWidth = listEl?.getBoundingClientRect?.().width || 0;
-					contentWidth = Math.max(1, listWidth - outputHorizontalPadding);
-				} catch {
-					let windowWidth = window.innerWidth;
-					let outputListMargin = 24 * 2;
-					contentWidth = Math.min(1240, windowWidth - outputListMargin - outputHorizontalPadding);
-				}
+				let contentWidth = listWidth
+					? Math.max(1, listWidth - outputHorizontalPadding)
+					: Math.min(1240, window.innerWidth - outputListMargin - outputHorizontalPadding);
 
 				let charWidth = this.get('responseBodyCharWidth') || 7;
 				return Math.max(1, Math.floor(contentWidth / charWidth));

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -236,6 +236,33 @@
 				justFocusedItem: false,
 			};
 		},
+		computed: {
+			responseBodyCharsPerLine () {
+				let contentWidth = 0;
+				let outputHorizontalPadding = 32 * 2;
+
+				try {
+					let listEl = this.find('.c-gp-results-raw-output_list');
+					let listWidth = listEl?.getBoundingClientRect?.().width || 0;
+					contentWidth = Math.max(1, listWidth - outputHorizontalPadding);
+				} catch {
+					let windowWidth = window.innerWidth;
+					let outputListMargin = 24 * 2;
+					contentWidth = Math.min(1240, windowWidth - outputListMargin - outputHorizontalPadding);
+				}
+
+				let charWidth = this.get('responseBodyCharWidth') || 7;
+				return Math.max(1, Math.floor(contentWidth / charWidth));
+			},
+			headerInfoAvailableHalfWidth () {
+				let listWidth = this.get('headerInfoListWidth') || 0;
+				let containerHorizontalPadding = 24 * 2;
+				let containerWidth = listWidth - containerHorizontalPadding;
+				let arrowMinWidth = 110;
+				let arrowMarginRight = 32;
+				return (containerWidth / 2) - ((arrowMinWidth + arrowMarginRight) / 2);
+			},
+		},
 		onrender () {
 			if (!Ractive.isServer) {
 				this.set('networkLookupsActive', true);
@@ -481,28 +508,11 @@
 			}
 		},
 		// --- Logic to determine whether to (always) show the HTTP response body ---
-		getResponseBodyCharsPerLine () {
-			let contentWidth = 0;
-			let outputHorizontalPadding = 32 * 2;
-
-			try {
-				let listEl = this.find('.c-gp-results-raw-output_list');
-				let listWidth = listEl?.getBoundingClientRect?.().width || 0;
-				contentWidth = Math.max(1, listWidth - outputHorizontalPadding);
-			} catch {
-				let windowWidth = window.innerWidth;
-				let outputListMargin = 24 * 2;
-				contentWidth = Math.min(1240, windowWidth - outputListMargin - outputHorizontalPadding);
-			}
-
-			let charWidth = this.get('responseBodyCharWidth') || 7;
-			return Math.max(1, Math.floor(contentWidth / charWidth));
-		},
 		isResponseBodyHidden (result) {
 			let activeTargetIdx = this.get('activeTargetIdx');
 			let body = result?.statsPerTarget?.[activeTargetIdx]?.responseBody || '';
 
-			if (!_.shouldCollapseResponseBody(body, this.getResponseBodyCharsPerLine())) {
+			if (!_.shouldCollapseResponseBody(body, this.get('responseBodyCharsPerLine'))) {
 				return false;
 			}
 
@@ -766,14 +776,6 @@
 
 			return widths;
 		},
-		getHeaderInfoAvailableHalfWidth () {
-			let listWidth = this.get('headerInfoListWidth') || 0;
-			let containerHorizontalPadding = 24 * 2;
-			let containerWidth = listWidth - containerHorizontalPadding;
-			let arrowMinWidth = 110;
-			let arrowMarginRight = 32;
-			return (containerWidth / 2) - ((arrowMinWidth + arrowMarginRight) / 2);
-		},
 		recalculateHeaderInfoLayoutStates ({ allowShrink = true, updateHeight = true } = {}) {
 			let listEl = this.find('.c-gp-results-raw-output_list');
 			let listWidth = listEl?.getBoundingClientRect?.().width || 0;
@@ -793,7 +795,7 @@
 				this.set('headerInfoListWidth', listWidth);
 			}
 
-			let availableHalfWidth = this.getHeaderInfoAvailableHalfWidth();
+			let availableHalfWidth = this.get('headerInfoAvailableHalfWidth');
 
 			preparedTestResults.forEach((result) => {
 				let resultId = result.clientSideId;
@@ -1014,7 +1016,7 @@
 			this.set(`hiddenTestResults[${activeTargetIdx}]`, updated);
 
 			// Reset the content state when closing output, but keep the current response-body state when opening it.
-			if (!isOpening && !hiddenContent.includes(resultId) && _.shouldCollapseResponseBody(body, this.getResponseBodyCharsPerLine())) {
+			if (!isOpening && !hiddenContent.includes(resultId) && _.shouldCollapseResponseBody(body, this.get('responseBodyCharsPerLine'))) {
 				this.set(`hiddenResponseBodies[${activeTargetIdx}]`, [ ...hiddenContent, resultId ]);
 			}
 		},

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -309,11 +309,11 @@
 						return;
 					}
 
-					this.recalculateHeaderInfoLayoutStates({ allowShrink: false });
+					this.setResultsBlockHeight({ allowShrink: false });
 				}, { deep: true, defer: true, init: false });
 
 				this.observe('hiddenResponseBodies', () => {
-					this.recalculateHeaderInfoLayoutStates({ allowShrink: false });
+					this.setResultsBlockHeight({ allowShrink: false });
 				}, { deep: true, defer: true, init: false });
 
 				this.observe('preparedTestResults activeTargetIdx', () => {

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -418,7 +418,7 @@
 
 			let nodeRect = node.getBoundingClientRect();
 			let containerRect = container.getBoundingClientRect();
-			let top = nodeRect.top - containerRect.top + nodeHeader.getBoundingClientRect().height / 2 - 13;
+			let top = nodeRect.top - containerRect.top + nodeHeader.offsetHeight / 2 - 13;
 			let left = nodeRect.left - containerRect.left - 26;
 
 			if (top !== floatingSetLocationButton.top || left !== floatingSetLocationButton.left) {
@@ -576,13 +576,13 @@
 					let limit = Math.min(itemsAmount, 3);
 
 					for (let i = 0; i < limit; i++) {
-						targetHeight += items[i].getBoundingClientRect().height;
+						targetHeight += items[i].offsetHeight;
 					}
 
 					let totalItemHeight = targetHeight;
 
 					for (let i = limit; i < itemsAmount; i++) {
-						totalItemHeight += items[i].getBoundingClientRect().height;
+						totalItemHeight += items[i].offsetHeight;
 					}
 
 					targetHeight = Math.ceil(targetHeight);
@@ -776,7 +776,7 @@
 		},
 		recalculateHeaderInfoLayoutStates ({ allowShrink = true, updateHeight = true } = {}) {
 			let listEl = this.find('.c-gp-results-raw-output_list');
-			let listWidth = listEl?.getBoundingClientRect?.().width || 0;
+			let listWidth = listEl?.offsetWidth || 0;
 			let preparedTestResults = this.get('preparedTestResults') || [];
 			let previousListWidth = this.get('headerInfoListWidth') || 0;
 			let headerInfoEntityWidthsByKey = this.get('headerInfoEntityWidthsByKey');

--- a/src/views/components/results-raw-output.html
+++ b/src/views/components/results-raw-output.html
@@ -747,7 +747,7 @@
 			let activeTargetIdx = this.get('activeTargetIdx');
 			let ipAddressSet = new Set(ipAddresses);
 			let preparedTestResults = this.get('preparedTestResults') || [];
-			let headerInfoEntityWidthsByKey = new Map(this.get('headerInfoEntityWidthsByKey'));
+			let headerInfoEntityWidthsByKey = this.get('headerInfoEntityWidthsByKey');
 
 			preparedTestResults.forEach((result) => {
 				let ipAddr = result?.statsPerTarget?.[activeTargetIdx]?.ipAddr;


### PR DESCRIPTION
As requested via Slack

- Invalidate cached header entity widths only for rows whose target IP received network data.
- Reuse cached header width results when the list width has not changed.
- Avoid updating `headerInfoOverflowByResultId` unless the overflow state actually changes.
