### PR TITLE
perf: optimize table output loading

### DIFF
--- a/src/views/components/results-table-output.html
+++ b/src/views/components/results-table-output.html
@@ -43,214 +43,215 @@
 				<div class="results-table_header_cell graph">Graph</div>
 			</div>
 
-			{{#each preparedTestResults}}
-				<div class="results-table_row row-num-{{this.clientSideId}} item-id-{{this.clientSideId}}"
-					tabindex="0"
-					role="button"
-					aria-label="Set as location for the next test"
-					on-focus="@this.enableItemFocused(@event, this.clientSideId)"
-					on-blur="@this.hideSetLocationButton(@event)"
-					on-keydown="@this.headerKeydownHandler(@event, this.clientSideId)"
-					on-mouseenter="@this.showSetLocationButton(this.clientSideId)"
-					on-mouseleave="@this.hideSetLocationButton(@event)"
-				>
-					<div class="results-table_row_location">
-						<span class="results-table_row_location_status-line">
-							<span
-								class="results-table_row_location_status-line_top"
-								style="background-color: {{_.getGpProbeStatusColor(this.statsPerTarget[0].avgTiming)}}">
+			{{#if isResultsShapeReady && preparedTestResults.length}}
+				{{#each preparedTestResults}}
+					<div class="results-table_row row-num-{{this.clientSideId}} item-id-{{this.clientSideId}}"
+						tabindex="0"
+						role="button"
+						aria-label="Set as location for the next test"
+						on-focus="@this.enableItemFocused(@event, this.clientSideId)"
+						on-blur="@this.hideSetLocationButton(@event)"
+						on-keydown="@this.headerKeydownHandler(@event, this.clientSideId)"
+						on-mouseenter="@this.showSetLocationButton(this.clientSideId)"
+						on-mouseleave="@this.hideSetLocationButton(@event)"
+					>
+						<div class="results-table_row_location">
+							<span class="results-table_row_location_status-line">
+								<span
+									class="results-table_row_location_status-line_top"
+									style="background-color: {{_.getGpProbeStatusColor(this.statsPerTarget[0].avgTiming)}}">
+								</span>
+								<span
+									class="results-table_row_location_status-line_bottom"
+									style="background-color: {{_.getGpProbeStatusColor(this.statsPerTarget[1] ? this.statsPerTarget[1].avgTiming : this.statsPerTarget[0].avgTiming)}}">
+								</span>
 							</span>
-							<span
-								class="results-table_row_location_status-line_bottom"
-								style="background-color: {{_.getGpProbeStatusColor(this.statsPerTarget[1] ? this.statsPerTarget[1].avgTiming : this.statsPerTarget[0].avgTiming)}}">
-							</span>
-						</span>
 
-						<img width="28" height="20" src="https://cdn.jsdelivr.net/npm/country-flag-icons@1.5.5/3x2/{{this.country}}.svg">
+							<img width="28" height="20" src="https://cdn.jsdelivr.net/npm/country-flag-icons@1.5.5/3x2/{{this.country}}.svg">
 
-						<div class="results-table_row_location_data">
-							<span>{{this.city}}, {{this.country}}, {{this.continent}}</span>
-							<span>{{this.network}}</span>
+							<div class="results-table_row_location_data">
+								<span>{{this.city}}, {{this.country}}, {{this.continent}}</span>
+								<span>{{this.network}}</span>
+							</div>
 						</div>
 
+						<div class="results-table_row_stats">
+							{{#each this.statsPerTarget}}
+								<div class="results-table_row_stats_subrow">
+									{{#if targetsCnt > 1}}
+										<div class="results-table_row_stats_subrow_cell targets">
+											<div class="results-table_row_stats_subrow_cell_value">
+												{{#if this.target}}
+													<span>{{this.target}}</span>
+												{{elseif testInProgress}}
+													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+												{{else}}
+													<span>—</span>
+												{{/if}}
+											</div>
+										</div>
+									{{/if}}
+
+									{{#if this.isFailed}}
+										<div class="results-table_row_stats_subrow_cell probe-failed">
+											<span>{{PROBE_FAILED_TEXT}}</span>
+											<div as-tooltip="`${this.failureRawOutput}`, 'top', true">
+												<img width="20" height="20" alt="" src="{{@shared.assetsHost}}/img/target-icon.svg">
+											</div>
+										</div>
+									{{elseif this.isOffline && !isInfiniteModeRes}}
+										<div class="results-table_row_stats_subrow_cell probe-offline">
+											<span>{{PROBE_OFFLINE_TEXT}}</span>
+										</div>
+									{{else}}
+										<div class="results-table_row_stats_subrow_cell quality">
+											<div class="results-table_row_stats_subrow_cell_value">
+												<span class="results-table_row_stats_subrow_cell_value_header">Quality</span>
+												{{#if this.qualityStr}}
+													<span>{{this.qualityStr}}</span>
+												{{elseif testInProgress}}
+													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+												{{else}}
+													<span>—</span>
+												{{/if}}
+											</div>
+										</div>
+
+										<div class="results-table_row_stats_subrow_cell rtt">
+											<div class="results-table_row_stats_subrow_cell_value">
+												<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
+													<span class="timings_header">
+														<span>rtt&nbsp;</span>
+														<span>last</span>
+													</span>
+
+													{{#if this.areTimingsReady}}
+														<span class="timings_value">
+															{{@this.formatTimingValue(this.lastTiming)}}
+															{{#if this.lastTiming !== PROBE_NO_TIMING_VALUE}}
+																<span class="timings_units">ms</span>
+															{{/if}}
+														</span>
+													{{elseif !this.areTimingsReady && testInProgress}}
+														<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+													{{else}}
+														<span>—</span>
+													{{/if}}
+												</span>
+
+												<span class="timings_separator">/</span>
+
+												<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
+													<span class="timings_header">
+														<span>rtt&nbsp;</span>
+														<span>min</span>
+													</span>
+
+													{{#if this.areTimingsReady}}
+														<span class="timings_value">
+															{{@this.formatTimingValue(this.minTiming)}}
+															{{#if this.minTiming !== PROBE_NO_TIMING_VALUE}}
+																<span class="timings_units">ms</span>
+															{{/if}}
+														</span>
+													{{elseif !this.areTimingsReady && testInProgress}}
+														<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+													{{else}}
+														<span>—</span>
+													{{/if}}
+												</span>
+
+												<span class="timings_separator">/</span>
+
+												<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
+													<span class="timings_header">
+														<span>rtt&nbsp;</span>
+														<span>avg</span>
+													</span>
+
+													{{#if this.areTimingsReady}}
+														<span class="timings_value">
+															{{@this.formatTimingValue(this.avgTiming)}}
+															{{#if this.avgTiming !== PROBE_NO_TIMING_VALUE}}
+																<span class="timings_units">ms</span>
+															{{/if}}
+														</span>
+													{{elseif !this.areTimingsReady && testInProgress}}
+														<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+													{{else}}
+														<span>—</span>
+													{{/if}}
+												</span>
+
+												<span class="timings_separator">/</span>
+
+												<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
+													<span class="timings_header">
+														<span>rtt&nbsp;</span>
+														<span>max</span>
+													</span>
+
+													{{#if this.areTimingsReady}}
+														<span class="timings_value">
+															{{@this.formatTimingValue(this.maxTiming)}}
+															{{#if this.maxTiming !== PROBE_NO_TIMING_VALUE}}
+																<span class="timings_units">ms</span>
+															{{/if}}
+														</span>
+													{{elseif !this.areTimingsReady && testInProgress}}
+														<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+													{{else}}
+														<span>—</span>
+													{{/if}}
+												</span>
+
+												{{#if this.areTimingsReady
+													&& this.minTiming !== PROBE_NO_TIMING_VALUE
+													&& this.avgTiming !== PROBE_NO_TIMING_VALUE
+													&& this.maxTiming !== PROBE_NO_TIMING_VALUE
+												}}
+													<span class="lg-screen-units">ms</span>
+												{{/if}}
+											</div>
+										</div>
+
+										<div class="results-table_row_stats_subrow_cell ip">
+											<div class="results-table_row_stats_subrow_cell_value">
+												<span class="results-table_row_stats_subrow_cell_value_header"><span class="hidden-xs">Resolved </span>IP</span>
+												{{#if this.ipAddr}}
+													<span class="visible-lg"> <!-- We break in two lines if the value has more than 4 non-empty groups. -->
+														{{#each splitIPv6(ipAddr)}}
+															{{this}}<br>
+														{{/each}}
+													</span>
+													<span class="hidden-lg text-ellipsis">{{this.ipAddr}}</span>
+												{{elseif !this.ipAddr && testInProgress}}
+													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+												{{else}}
+													<span>—</span>
+												{{/if}}
+											</div>
+										</div>
+
+										<div class="results-table_row_stats_subrow_cell graph">
+											<div class="results-table_row_stats_subrow_cell_value">
+												<span class="results-table_row_stats_subrow_cell_value_header">Graph</span>
+												{{#if typeof this.packetsRtt !== 'undefined' && this.packetsRtt.length}}
+													<div>{{{ @this.createGraph(this.packetsRtt) }}}</div>
+												{{elseif testInProgress && testInProgress}}
+													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+												{{else}}
+													<span>—</span>
+												{{/if}}
+											</div>
+										</div>
+									{{/if}}
+								</div>
+							{{/each}}
+						</div>
 					</div>
-
-					<div class="results-table_row_stats">
-						{{#each this.statsPerTarget}}
-							<div class="results-table_row_stats_subrow">
-								{{#if targetsCnt > 1}}
-									<div class="results-table_row_stats_subrow_cell targets">
-										<div class="results-table_row_stats_subrow_cell_value">
-											{{#if this.target}}
-												<span>{{this.target}}</span>
-											{{elseif testInProgress}}
-												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-											{{else}}
-												<span>—</span>
-											{{/if}}
-										</div>
-									</div>
-								{{/if}}
-
-								{{#if this.isFailed}}
-									<div class="results-table_row_stats_subrow_cell probe-failed">
-										<span>{{PROBE_FAILED_TEXT}}</span>
-										<div as-tooltip="`${this.failureRawOutput}`, 'top', true">
-											<img width="20" height="20" src="{{@shared.assetsHost}}/img/target-icon.svg">
-										</div>
-									</div>
-								{{elseif this.isOffline && !isInfiniteModeRes}}
-									<div class="results-table_row_stats_subrow_cell probe-offline">
-										<span>{{PROBE_OFFLINE_TEXT}}</span>
-									</div>
-								{{else}}
-									<div class="results-table_row_stats_subrow_cell quality">
-										<div class="results-table_row_stats_subrow_cell_value">
-											<span class="results-table_row_stats_subrow_cell_value_header">Quality</span>
-											{{#if this.qualityStr}}
-												<span>{{this.qualityStr}}</span>
-											{{elseif testInProgress}}
-												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-											{{else}}
-												<span>—</span>
-											{{/if}}
-										</div>
-									</div>
-
-									<div class="results-table_row_stats_subrow_cell rtt">
-										<div class="results-table_row_stats_subrow_cell_value">
-											<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
-												<span class="timings_header">
-													<span>rtt&nbsp;</span>
-													<span>last</span>
-												</span>
-
-												{{#if this.areTimingsReady}}
-													<span class="timings_value">
-														{{@this.formatTimingValue(this.lastTiming)}}
-														{{#if this.lastTiming !== PROBE_NO_TIMING_VALUE}}
-															<span class="timings_units">ms</span>
-														{{/if}}
-													</span>
-												{{elseif !this.areTimingsReady && testInProgress}}
-													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-												{{else}}
-													<span>—</span>
-												{{/if}}
-											</span>
-
-											<span class="timings_separator">/</span>
-
-											<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
-												<span class="timings_header">
-													<span>rtt&nbsp;</span>
-													<span>min</span>
-												</span>
-
-												{{#if this.areTimingsReady}}
-													<span class="timings_value">
-														{{@this.formatTimingValue(this.minTiming)}}
-														{{#if this.minTiming !== PROBE_NO_TIMING_VALUE}}
-															<span class="timings_units">ms</span>
-														{{/if}}
-													</span>
-												{{elseif !this.areTimingsReady && testInProgress}}
-													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-												{{else}}
-													<span>—</span>
-												{{/if}}
-											</span>
-
-											<span class="timings_separator">/</span>
-
-											<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
-												<span class="timings_header">
-													<span>rtt&nbsp;</span>
-													<span>avg</span>
-												</span>
-
-												{{#if this.areTimingsReady}}
-													<span class="timings_value">
-														{{@this.formatTimingValue(this.avgTiming)}}
-														{{#if this.avgTiming !== PROBE_NO_TIMING_VALUE}}
-															<span class="timings_units">ms</span>
-														{{/if}}
-													</span>
-												{{elseif !this.areTimingsReady && testInProgress}}
-													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-												{{else}}
-													<span>—</span>
-												{{/if}}
-											</span>
-
-											<span class="timings_separator">/</span>
-
-											<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
-												<span class="timings_header">
-													<span>rtt&nbsp;</span>
-													<span>max</span>
-												</span>
-
-												{{#if this.areTimingsReady}}
-													<span class="timings_value">
-														{{@this.formatTimingValue(this.maxTiming)}}
-														{{#if this.maxTiming !== PROBE_NO_TIMING_VALUE}}
-															<span class="timings_units">ms</span>
-														{{/if}}
-													</span>
-												{{elseif !this.areTimingsReady && testInProgress}}
-													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-												{{else}}
-													<span>—</span>
-												{{/if}}
-											</span>
-
-											{{#if this.areTimingsReady
-												&& this.minTiming !== PROBE_NO_TIMING_VALUE
-												&& this.avgTiming !== PROBE_NO_TIMING_VALUE
-												&& this.maxTiming !== PROBE_NO_TIMING_VALUE
-											}}
-												<span class="lg-screen-units">ms</span>
-											{{/if}}
-										</div>
-									</div>
-
-									<div class="results-table_row_stats_subrow_cell ip">
-										<div class="results-table_row_stats_subrow_cell_value">
-											<span class="results-table_row_stats_subrow_cell_value_header"><span class="hidden-xs">Resolved </span>IP</span>
-											{{#if this.ipAddr}}
-												<span class="visible-lg"> <!-- We break in two lines if the value has more than 4 non-empty groups. -->
-													{{#each splitIPv6(ipAddr)}}
-														{{this}}<br>
-													{{/each}}
-												</span>
-												<span class="hidden-lg text-ellipsis">{{this.ipAddr}}</span>
-											{{elseif !this.ipAddr && testInProgress}}
-												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-											{{else}}
-												<span>—</span>
-											{{/if}}
-										</div>
-									</div>
-
-									<div class="results-table_row_stats_subrow_cell graph">
-										<div class="results-table_row_stats_subrow_cell_value">
-											<span class="results-table_row_stats_subrow_cell_value_header">Graph</span>
-											{{#if typeof this.packetsRtt !== 'undefined' && this.packetsRtt.length}}
-												<div>{{{ @this.createGraph(this.packetsRtt) }}}</div>
-											{{elseif testInProgress && testInProgress}}
-												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-											{{else}}
-												<span>—</span>
-											{{/if}}
-										</div>
-									</div>
-								{{/if}}
-							</div>
-						{{/each}}
-					</div>
-				</div>
-			{{/each}}
+				{{/each}}
+			{{/if}}
 		</div>
 	</div>
 
@@ -314,16 +315,33 @@
 				justFocusedItem: false,
 			};
 		},
+		computed: {
+			isResultsShapeReady () {
+				let expectedTargetsCnt = this.get('expectedTargetsCnt');
+				let preparedTestResults = this.get('preparedTestResults') || [];
+				let actualTargetsCnt = preparedTestResults[0]?.statsPerTarget?.length || 0;
+
+				return !expectedTargetsCnt || actualTargetsCnt >= expectedTargetsCnt;
+			},
+		},
 		onrender () {
 			if (!Ractive.isServer) {
 				listeners.screenWidthListener(this);
 
 				this.observe('screenWidth', () => {
+					if (!this.get('isResultsShapeReady')) { return; }
+
 					let preparedTestResults = this.get('preparedTestResults');
-					preparedTestResults && this.setResultsBlockHeight(preparedTestResults);
+					preparedTestResults.length && this.setResultsBlockHeight(preparedTestResults);
 				});
 
-				this.observe('preparedTestResults', (preparedTestResults) => {
+				this.observe('preparedTestResults isResultsShapeReady', () => {
+					if (!this.get('isResultsShapeReady')) { return; }
+
+					let preparedTestResults = this.get('preparedTestResults') || [];
+
+					if (!preparedTestResults.length) { return; }
+
 					this.setChartMaxHeight(preparedTestResults);
 					// set results block height based on content
 					this.setResultsBlockHeight(preparedTestResults);
@@ -397,6 +415,10 @@
 			if (event?.type === 'scroll') {
 				this.set('floatingSetLocationButton.visible', false);
 				this.set('itemFocused', false);
+				return;
+			}
+
+			if (!this.get('floatingSetLocationButton.visible') && !this.get('itemFocused')) {
 				return;
 			}
 

--- a/src/views/components/results-table-output.html
+++ b/src/views/components/results-table-output.html
@@ -43,7 +43,7 @@
 				<div class="results-table_header_cell graph">Graph</div>
 			</div>
 
-			{{#if isResultsShapeReady && preparedTestResults.length}}
+			{{#if preparedTestResults.length}}
 				{{#each preparedTestResults}}
 					<div class="results-table_row row-num-{{this.clientSideId}} item-id-{{this.clientSideId}}"
 						tabindex="0"
@@ -315,29 +315,16 @@
 				justFocusedItem: false,
 			};
 		},
-		computed: {
-			isResultsShapeReady () {
-				let expectedTargetsCnt = this.get('expectedTargetsCnt');
-				let preparedTestResults = this.get('preparedTestResults') || [];
-				let actualTargetsCnt = preparedTestResults[0]?.statsPerTarget?.length || 0;
-
-				return !expectedTargetsCnt || actualTargetsCnt >= expectedTargetsCnt;
-			},
-		},
 		onrender () {
 			if (!Ractive.isServer) {
 				listeners.screenWidthListener(this);
 
 				this.observe('screenWidth', () => {
-					if (!this.get('isResultsShapeReady')) { return; }
-
 					let preparedTestResults = this.get('preparedTestResults');
 					preparedTestResults.length && this.setResultsBlockHeight(preparedTestResults);
 				});
 
-				this.observe('preparedTestResults isResultsShapeReady', () => {
-					if (!this.get('isResultsShapeReady')) { return; }
-
+				this.observe('preparedTestResults', () => {
 					let preparedTestResults = this.get('preparedTestResults') || [];
 
 					if (!preparedTestResults.length) { return; }

--- a/src/views/components/results-table-output.html
+++ b/src/views/components/results-table-output.html
@@ -43,215 +43,213 @@
 				<div class="results-table_header_cell graph">Graph</div>
 			</div>
 
-			{{#if preparedTestResults.length}}
-				{{#each preparedTestResults}}
-					<div class="results-table_row row-num-{{this.clientSideId}} item-id-{{this.clientSideId}}"
-						tabindex="0"
-						role="button"
-						aria-label="Set as location for the next test"
-						on-focus="@this.enableItemFocused(@event, this.clientSideId)"
-						on-blur="@this.hideSetLocationButton(@event)"
-						on-keydown="@this.headerKeydownHandler(@event, this.clientSideId)"
-						on-mouseenter="@this.showSetLocationButton(this.clientSideId)"
-						on-mouseleave="@this.hideSetLocationButton(@event)"
-					>
-						<div class="results-table_row_location">
-							<span class="results-table_row_location_status-line">
-								<span
-									class="results-table_row_location_status-line_top"
-									style="background-color: {{_.getGpProbeStatusColor(this.statsPerTarget[0].avgTiming)}}">
-								</span>
-								<span
-									class="results-table_row_location_status-line_bottom"
-									style="background-color: {{_.getGpProbeStatusColor(this.statsPerTarget[1] ? this.statsPerTarget[1].avgTiming : this.statsPerTarget[0].avgTiming)}}">
-								</span>
+			{{#each preparedTestResults}}
+				<div class="results-table_row row-num-{{this.clientSideId}} item-id-{{this.clientSideId}}"
+					tabindex="0"
+					role="button"
+					aria-label="Set as location for the next test"
+					on-focus="@this.enableItemFocused(@event, this.clientSideId)"
+					on-blur="@this.hideSetLocationButton(@event)"
+					on-keydown="@this.headerKeydownHandler(@event, this.clientSideId)"
+					on-mouseenter="@this.showSetLocationButton(this.clientSideId)"
+					on-mouseleave="@this.hideSetLocationButton(@event)"
+				>
+					<div class="results-table_row_location">
+						<span class="results-table_row_location_status-line">
+							<span
+								class="results-table_row_location_status-line_top"
+								style="background-color: {{_.getGpProbeStatusColor(this.statsPerTarget[0].avgTiming)}}">
 							</span>
+							<span
+								class="results-table_row_location_status-line_bottom"
+								style="background-color: {{_.getGpProbeStatusColor(this.statsPerTarget[1] ? this.statsPerTarget[1].avgTiming : this.statsPerTarget[0].avgTiming)}}">
+							</span>
+						</span>
 
-							<img width="28" height="20" alt="" src="https://cdn.jsdelivr.net/npm/country-flag-icons@1.5.5/3x2/{{this.country}}.svg">
+						<img width="28" height="20" alt="" src="https://cdn.jsdelivr.net/npm/country-flag-icons@1.5.5/3x2/{{this.country}}.svg">
 
-							<div class="results-table_row_location_data">
-								<span>{{this.city}}, {{this.country}}, {{this.continent}}</span>
-								<span>{{this.network}}</span>
-							</div>
-						</div>
-
-						<div class="results-table_row_stats">
-							{{#each this.statsPerTarget}}
-								<div class="results-table_row_stats_subrow">
-									{{#if targetsCnt > 1}}
-										<div class="results-table_row_stats_subrow_cell targets">
-											<div class="results-table_row_stats_subrow_cell_value">
-												{{#if this.target}}
-													<span>{{this.target}}</span>
-												{{elseif testInProgress}}
-													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-												{{else}}
-													<span>—</span>
-												{{/if}}
-											</div>
-										</div>
-									{{/if}}
-
-									{{#if this.isFailed}}
-										<div class="results-table_row_stats_subrow_cell probe-failed">
-											<span>{{PROBE_FAILED_TEXT}}</span>
-											<div as-tooltip="`${this.failureRawOutput}`, 'top', true">
-												<img width="20" height="20" alt="" src="{{@shared.assetsHost}}/img/target-icon.svg">
-											</div>
-										</div>
-									{{elseif this.isOffline && !isInfiniteModeRes}}
-										<div class="results-table_row_stats_subrow_cell probe-offline">
-											<span>{{PROBE_OFFLINE_TEXT}}</span>
-										</div>
-									{{else}}
-										<div class="results-table_row_stats_subrow_cell quality">
-											<div class="results-table_row_stats_subrow_cell_value">
-												<span class="results-table_row_stats_subrow_cell_value_header">Quality</span>
-												{{#if this.qualityStr}}
-													<span>{{this.qualityStr}}</span>
-												{{elseif testInProgress}}
-													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-												{{else}}
-													<span>—</span>
-												{{/if}}
-											</div>
-										</div>
-
-										<div class="results-table_row_stats_subrow_cell rtt">
-											<div class="results-table_row_stats_subrow_cell_value">
-												<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
-													<span class="timings_header">
-														<span>rtt&nbsp;</span>
-														<span>last</span>
-													</span>
-
-													{{#if this.areTimingsReady}}
-														<span class="timings_value">
-															{{@this.formatTimingValue(this.lastTiming)}}
-															{{#if this.lastTiming !== PROBE_NO_TIMING_VALUE}}
-																<span class="timings_units">ms</span>
-															{{/if}}
-														</span>
-													{{elseif !this.areTimingsReady && testInProgress}}
-														<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-													{{else}}
-														<span>—</span>
-													{{/if}}
-												</span>
-
-												<span class="timings_separator">/</span>
-
-												<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
-													<span class="timings_header">
-														<span>rtt&nbsp;</span>
-														<span>min</span>
-													</span>
-
-													{{#if this.areTimingsReady}}
-														<span class="timings_value">
-															{{@this.formatTimingValue(this.minTiming)}}
-															{{#if this.minTiming !== PROBE_NO_TIMING_VALUE}}
-																<span class="timings_units">ms</span>
-															{{/if}}
-														</span>
-													{{elseif !this.areTimingsReady && testInProgress}}
-														<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-													{{else}}
-														<span>—</span>
-													{{/if}}
-												</span>
-
-												<span class="timings_separator">/</span>
-
-												<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
-													<span class="timings_header">
-														<span>rtt&nbsp;</span>
-														<span>avg</span>
-													</span>
-
-													{{#if this.areTimingsReady}}
-														<span class="timings_value">
-															{{@this.formatTimingValue(this.avgTiming)}}
-															{{#if this.avgTiming !== PROBE_NO_TIMING_VALUE}}
-																<span class="timings_units">ms</span>
-															{{/if}}
-														</span>
-													{{elseif !this.areTimingsReady && testInProgress}}
-														<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-													{{else}}
-														<span>—</span>
-													{{/if}}
-												</span>
-
-												<span class="timings_separator">/</span>
-
-												<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
-													<span class="timings_header">
-														<span>rtt&nbsp;</span>
-														<span>max</span>
-													</span>
-
-													{{#if this.areTimingsReady}}
-														<span class="timings_value">
-															{{@this.formatTimingValue(this.maxTiming)}}
-															{{#if this.maxTiming !== PROBE_NO_TIMING_VALUE}}
-																<span class="timings_units">ms</span>
-															{{/if}}
-														</span>
-													{{elseif !this.areTimingsReady && testInProgress}}
-														<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-													{{else}}
-														<span>—</span>
-													{{/if}}
-												</span>
-
-												{{#if this.areTimingsReady
-													&& this.minTiming !== PROBE_NO_TIMING_VALUE
-													&& this.avgTiming !== PROBE_NO_TIMING_VALUE
-													&& this.maxTiming !== PROBE_NO_TIMING_VALUE
-												}}
-													<span class="lg-screen-units">ms</span>
-												{{/if}}
-											</div>
-										</div>
-
-										<div class="results-table_row_stats_subrow_cell ip">
-											<div class="results-table_row_stats_subrow_cell_value">
-												<span class="results-table_row_stats_subrow_cell_value_header"><span class="hidden-xs">Resolved </span>IP</span>
-												{{#if this.ipAddr}}
-													<span class="visible-lg"> <!-- We break in two lines if the value has more than 4 non-empty groups. -->
-														{{#each splitIPv6(ipAddr)}}
-															{{this}}<br>
-														{{/each}}
-													</span>
-													<span class="hidden-lg text-ellipsis">{{this.ipAddr}}</span>
-												{{elseif !this.ipAddr && testInProgress}}
-													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-												{{else}}
-													<span>—</span>
-												{{/if}}
-											</div>
-										</div>
-
-										<div class="results-table_row_stats_subrow_cell graph">
-											<div class="results-table_row_stats_subrow_cell_value">
-												<span class="results-table_row_stats_subrow_cell_value_header">Graph</span>
-												{{#if typeof this.packetsRtt !== 'undefined' && this.packetsRtt.length}}
-													<div>{{{ @this.createGraph(this.packetsRtt) }}}</div>
-												{{elseif testInProgress && testInProgress}}
-													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
-												{{else}}
-													<span>—</span>
-												{{/if}}
-											</div>
-										</div>
-									{{/if}}
-								</div>
-							{{/each}}
+						<div class="results-table_row_location_data">
+							<span>{{this.city}}, {{this.country}}, {{this.continent}}</span>
+							<span>{{this.network}}</span>
 						</div>
 					</div>
-				{{/each}}
-			{{/if}}
+
+					<div class="results-table_row_stats">
+						{{#each this.statsPerTarget}}
+							<div class="results-table_row_stats_subrow">
+								{{#if targetsCnt > 1}}
+									<div class="results-table_row_stats_subrow_cell targets">
+										<div class="results-table_row_stats_subrow_cell_value">
+											{{#if this.target}}
+												<span>{{this.target}}</span>
+											{{elseif testInProgress}}
+												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+											{{else}}
+												<span>—</span>
+											{{/if}}
+										</div>
+									</div>
+								{{/if}}
+
+								{{#if this.isFailed}}
+									<div class="results-table_row_stats_subrow_cell probe-failed">
+										<span>{{PROBE_FAILED_TEXT}}</span>
+										<div as-tooltip="`${this.failureRawOutput}`, 'top', true">
+											<img width="20" height="20" alt="" src="{{@shared.assetsHost}}/img/target-icon.svg">
+										</div>
+									</div>
+								{{elseif this.isOffline && !isInfiniteModeRes}}
+									<div class="results-table_row_stats_subrow_cell probe-offline">
+										<span>{{PROBE_OFFLINE_TEXT}}</span>
+									</div>
+								{{else}}
+									<div class="results-table_row_stats_subrow_cell quality">
+										<div class="results-table_row_stats_subrow_cell_value">
+											<span class="results-table_row_stats_subrow_cell_value_header">Quality</span>
+											{{#if this.qualityStr}}
+												<span>{{this.qualityStr}}</span>
+											{{elseif testInProgress}}
+												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+											{{else}}
+												<span>—</span>
+											{{/if}}
+										</div>
+									</div>
+
+									<div class="results-table_row_stats_subrow_cell rtt">
+										<div class="results-table_row_stats_subrow_cell_value">
+											<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
+												<span class="timings_header">
+													<span>rtt&nbsp;</span>
+													<span>last</span>
+												</span>
+
+												{{#if this.areTimingsReady}}
+													<span class="timings_value">
+														{{@this.formatTimingValue(this.lastTiming)}}
+														{{#if this.lastTiming !== PROBE_NO_TIMING_VALUE}}
+															<span class="timings_units">ms</span>
+														{{/if}}
+													</span>
+												{{elseif !this.areTimingsReady && testInProgress}}
+													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+												{{else}}
+													<span>—</span>
+												{{/if}}
+											</span>
+
+											<span class="timings_separator">/</span>
+
+											<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
+												<span class="timings_header">
+													<span>rtt&nbsp;</span>
+													<span>min</span>
+												</span>
+
+												{{#if this.areTimingsReady}}
+													<span class="timings_value">
+														{{@this.formatTimingValue(this.minTiming)}}
+														{{#if this.minTiming !== PROBE_NO_TIMING_VALUE}}
+															<span class="timings_units">ms</span>
+														{{/if}}
+													</span>
+												{{elseif !this.areTimingsReady && testInProgress}}
+													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+												{{else}}
+													<span>—</span>
+												{{/if}}
+											</span>
+
+											<span class="timings_separator">/</span>
+
+											<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
+												<span class="timings_header">
+													<span>rtt&nbsp;</span>
+													<span>avg</span>
+												</span>
+
+												{{#if this.areTimingsReady}}
+													<span class="timings_value">
+														{{@this.formatTimingValue(this.avgTiming)}}
+														{{#if this.avgTiming !== PROBE_NO_TIMING_VALUE}}
+															<span class="timings_units">ms</span>
+														{{/if}}
+													</span>
+												{{elseif !this.areTimingsReady && testInProgress}}
+													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+												{{else}}
+													<span>—</span>
+												{{/if}}
+											</span>
+
+											<span class="timings_separator">/</span>
+
+											<span class="timings {{#unless areTimingsReady}}no-value{{/unless}}">
+												<span class="timings_header">
+													<span>rtt&nbsp;</span>
+													<span>max</span>
+												</span>
+
+												{{#if this.areTimingsReady}}
+													<span class="timings_value">
+														{{@this.formatTimingValue(this.maxTiming)}}
+														{{#if this.maxTiming !== PROBE_NO_TIMING_VALUE}}
+															<span class="timings_units">ms</span>
+														{{/if}}
+													</span>
+												{{elseif !this.areTimingsReady && testInProgress}}
+													<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+												{{else}}
+													<span>—</span>
+												{{/if}}
+											</span>
+
+											{{#if this.areTimingsReady
+												&& this.minTiming !== PROBE_NO_TIMING_VALUE
+												&& this.avgTiming !== PROBE_NO_TIMING_VALUE
+												&& this.maxTiming !== PROBE_NO_TIMING_VALUE
+											}}
+												<span class="lg-screen-units">ms</span>
+											{{/if}}
+										</div>
+									</div>
+
+									<div class="results-table_row_stats_subrow_cell ip">
+										<div class="results-table_row_stats_subrow_cell_value">
+											<span class="results-table_row_stats_subrow_cell_value_header"><span class="hidden-xs">Resolved </span>IP</span>
+											{{#if this.ipAddr}}
+												<span class="visible-lg"> <!-- We break in two lines if the value has more than 4 non-empty groups. -->
+													{{#each splitIPv6(ipAddr)}}
+														{{this}}<br>
+													{{/each}}
+												</span>
+												<span class="hidden-lg text-ellipsis">{{this.ipAddr}}</span>
+											{{elseif !this.ipAddr && testInProgress}}
+												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+											{{else}}
+												<span>—</span>
+											{{/if}}
+										</div>
+									</div>
+
+									<div class="results-table_row_stats_subrow_cell graph">
+										<div class="results-table_row_stats_subrow_cell_value">
+											<span class="results-table_row_stats_subrow_cell_value_header">Graph</span>
+											{{#if typeof this.packetsRtt !== 'undefined' && this.packetsRtt.length}}
+												<div>{{{ @this.createGraph(this.packetsRtt) }}}</div>
+											{{elseif testInProgress && testInProgress}}
+												<c-placeholder-skeleton type="subheader"></c-placeholder-skeleton>
+											{{else}}
+												<span>—</span>
+											{{/if}}
+										</div>
+									</div>
+								{{/if}}
+							</div>
+						{{/each}}
+					</div>
+				</div>
+			{{/each}}
 		</div>
 	</div>
 

--- a/src/views/components/results-table-output.html
+++ b/src/views/components/results-table-output.html
@@ -6,7 +6,7 @@
 			<div class="results-table_header">
 				<button class="results-table_header_cell location" on-click="@this.onSortClick('location')">
 					Location
-					<img width="8" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('location')}}">
+					<img width="8" alt="" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('location')}}">
 				</button>
 
 				{{#if targetsCnt > 1}}
@@ -15,28 +15,28 @@
 
 				<button class="results-table_header_cell quality" on-click="@this.onSortClick('quality')">
 					Quality
-					<img width="8" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('quality')}}">
+					<img width="8" alt="" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('quality')}}">
 				</button>
 
 				<div class="results-table_header_cell rtt">
 					<button class="rtt_text" on-click="@this.onSortClick('rtt-last')">
 						rtt last
-						<img width="8" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('rtt-last')}}">
+						<img width="8" alt="" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('rtt-last')}}">
 					</button>
 					<span class="rtt_separator">/</span>
 					<button class="rtt_text" on-click="@this.onSortClick('min')">
 						min
-						<img width="8" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('min')}}">
+						<img width="8" alt="" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('min')}}">
 					</button>
 					<span class="rtt_separator">/</span>
 					<button class="rtt_text" on-click="@this.onSortClick('avg')">
 						avg
-						<img width="8" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('avg')}}">
+						<img width="8" alt="" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('avg')}}">
 					</button>
 					<span class="rtt_separator">/</span>
 					<button class="rtt_text" on-click="@this.onSortClick('max')">
 						max
-						<img width="8" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('max')}}">
+						<img width="8" alt="" src="{{@shared.assetsHost}}/img/{{@this.getSortIcon('max')}}">
 					</button>
 				</div>
 				<div class="results-table_header_cell ip">Resolved IP</div>
@@ -67,7 +67,7 @@
 								</span>
 							</span>
 
-							<img width="28" height="20" src="https://cdn.jsdelivr.net/npm/country-flag-icons@1.5.5/3x2/{{this.country}}.svg">
+							<img width="28" height="20" alt="" src="https://cdn.jsdelivr.net/npm/country-flag-icons@1.5.5/3x2/{{this.country}}.svg">
 
 							<div class="results-table_row_location_data">
 								<span>{{this.city}}, {{this.country}}, {{this.continent}}</span>

--- a/src/views/pages/_index.html
+++ b/src/views/pages/_index.html
@@ -688,7 +688,7 @@
 						<p>{{{measurementErrMsg}}}</p>
 					</div>
 				</div>
-			{{elseif testResults}}
+			{{elseif testResults && (rawOutputMode || tableOutputReady)}}
 				<div class="gp_map-block_test-output">
 					<c-gp-results-controls
 						showMap="{{showMap}}"
@@ -733,9 +733,8 @@
 							<c-gp-results-table-output
 								testReqParams="{{testReqParams}}"
 								testInProgress="{{testInProgress}}"
-								preparedTestResults="{{tablePreparedTestResults}}"
+								preparedTestResults="{{preparedTestResults}}"
 								targetsCnt="{{targetsArr.length}}"
-								expectedTargetsCnt="{{isInfiniteModeRes ? targetsArr.length : (qsMeasurementIdsArr.length > 1 ? qsMeasurementIdsArr.length : targetsArr.length)}}"
 								currSearchLocation="{{mainOptions.location}}"
 								measurementsMetadata="{{measurementsMetadata}}"
 								isInfiniteModeRes="{{isInfiniteModeRes}}"
@@ -1617,7 +1616,6 @@
 	const PROBE_STATUS_OFFLINE = _.getProbeStatusOfflineValue();
 	const PROBE_OFFLINE_TEXT = 'Probe offline';
 	const RAW_OUTPUT_LINES_BATCH_LIMIT = 40;
-	const TABLE_RESULTS_UPDATE_INTERVAL = 1500;
 	const DEFAULT_TARGET_VALUE = 'cdn.jsdelivr.net';
 	const INFINITE_MEASUREMENT_PACKETS = 16;
 	const INFINITE_MEASUREMENT_LIMIT = 5;
@@ -1782,7 +1780,6 @@
 				isInfiniteModeRes: false,
 				prevProbesMeasId: null,
 				preparedTestResults: [],
-				tablePreparedTestResults: [],
 				ddHandlerSet: false,
 				showCreditsData: false,
 				rateCreditsData: null,
@@ -1859,6 +1856,15 @@
 				}
 
 				return true;
+			},
+			tableOutputReady () {
+				let preparedTestResults = this.get('preparedTestResults') || [];
+				let expectedTargetsCnt = this.get('isInfiniteModeRes') || this.get('qsMeasurementIdsArr.length') <= 1
+					? this.get('targetsArr.length')
+					: this.get('qsMeasurementIdsArr.length');
+				let actualTargetsCnt = preparedTestResults[0]?.statsPerTarget?.length || 0;
+
+				return preparedTestResults.length && (!expectedTargetsCnt || actualTargetsCnt >= expectedTargetsCnt);
 			},
 			anyResponseBodyCollapsible () {
 				if (Ractive.isServer) {
@@ -2004,10 +2010,6 @@
 							this.set('preparedTestResults', sortedResults);
 						}
 					}
-				});
-
-				this.observe('preparedTestResults rawOutputMode testInProgress', () => {
-					this.scheduleTablePreparedTestResultsUpdate();
 				});
 
 				// clear table sort params and enable rawOutputMode whenever test type isn't ping
@@ -2550,60 +2552,11 @@
 			}
 
 			clearTimeout(this.get('runTestBtnDelayTimeout'));
-			clearTimeout(this.tableResultsUpdateTimeout);
 			this.get('testReqCancelFn')?.forEach(cancel => cancel?.());
 			this.set('testReqCancelFn', []);
 		},
 		isActiveTestRun (testRunId) {
 			return testRunId === null || testRunId === undefined || testRunId === this.get('activeTestRunId');
-		},
-		updateTablePreparedTestResults () {
-			let preparedTestResults = this.get('preparedTestResults') || [];
-
-			this.set('tablePreparedTestResults', preparedTestResults);
-			this.lastTableResultsUpdate = performance.now();
-		},
-		isTableResultsShapeReady (preparedTestResults = this.get('tablePreparedTestResults') || []) {
-			let expectedTargetsCnt = this.get('targetsArr.length');
-
-			if (!this.get('isInfiniteModeRes') && this.get('qsMeasurementIdsArr.length') > 1) {
-				expectedTargetsCnt = this.get('qsMeasurementIdsArr.length');
-			}
-
-			let actualTargetsCnt = preparedTestResults[0]?.statsPerTarget?.length || 0;
-
-			return !expectedTargetsCnt || actualTargetsCnt >= expectedTargetsCnt;
-		},
-		scheduleTablePreparedTestResultsUpdate () {
-			if (this.get('rawOutputMode')) {
-				clearTimeout(this.tableResultsUpdateTimeout);
-				this.tableResultsUpdateTimeout = null;
-				return;
-			}
-
-			let preparedTestResults = this.get('preparedTestResults') || [];
-			let tablePreparedTestResults = this.get('tablePreparedTestResults') || [];
-			let hasRenderedResults = tablePreparedTestResults.length && this.isTableResultsShapeReady(tablePreparedTestResults);
-
-			if (!preparedTestResults.length || !this.get('testInProgress') || !hasRenderedResults) {
-				clearTimeout(this.tableResultsUpdateTimeout);
-				this.tableResultsUpdateTimeout = null;
-
-				this.updateTablePreparedTestResults();
-				return;
-			}
-
-			if (this.tableResultsUpdateTimeout) {
-				return;
-			}
-
-			let elapsed = performance.now() - (this.lastTableResultsUpdate || 0);
-			let delay = Math.max(TABLE_RESULTS_UPDATE_INTERVAL - elapsed, 0);
-
-			this.tableResultsUpdateTimeout = setTimeout(() => {
-				this.tableResultsUpdateTimeout = null;
-				this.updateTablePreparedTestResults();
-			}, delay);
 		},
 		handleRunTestBtn () {
 			if (this.get('runTestBtnDisabled')) {

--- a/src/views/pages/_index.html
+++ b/src/views/pages/_index.html
@@ -733,8 +733,9 @@
 							<c-gp-results-table-output
 								testReqParams="{{testReqParams}}"
 								testInProgress="{{testInProgress}}"
-								preparedTestResults="{{preparedTestResults}}"
+								preparedTestResults="{{tablePreparedTestResults}}"
 								targetsCnt="{{targetsArr.length}}"
+								expectedTargetsCnt="{{isInfiniteModeRes ? targetsArr.length : (qsMeasurementIdsArr.length > 1 ? qsMeasurementIdsArr.length : targetsArr.length)}}"
 								currSearchLocation="{{mainOptions.location}}"
 								measurementsMetadata="{{measurementsMetadata}}"
 								isInfiniteModeRes="{{isInfiniteModeRes}}"
@@ -1616,6 +1617,7 @@
 	const PROBE_STATUS_OFFLINE = _.getProbeStatusOfflineValue();
 	const PROBE_OFFLINE_TEXT = 'Probe offline';
 	const RAW_OUTPUT_LINES_BATCH_LIMIT = 40;
+	const TABLE_RESULTS_UPDATE_INTERVAL = 1500;
 	const DEFAULT_TARGET_VALUE = 'cdn.jsdelivr.net';
 	const INFINITE_MEASUREMENT_PACKETS = 16;
 	const INFINITE_MEASUREMENT_LIMIT = 5;
@@ -1780,6 +1782,7 @@
 				isInfiniteModeRes: false,
 				prevProbesMeasId: null,
 				preparedTestResults: [],
+				tablePreparedTestResults: [],
 				ddHandlerSet: false,
 				showCreditsData: false,
 				rateCreditsData: null,
@@ -1858,14 +1861,19 @@
 				return true;
 			},
 			anyResponseBodyCollapsible () {
+				if (Ractive.isServer) {
+					return false;
+				}
+
 				let preparedTestResults = this.get('preparedTestResults') || [];
 				let targetsArr = this.get('targetsArr') || [];
+				let charsPerLine = this.getRawOutputCharsPerLine();
 
 				for (let targetIdx = 0; targetIdx < targetsArr.length; targetIdx++) {
 					for (let i = 0; i < preparedTestResults.length; i++) {
 						let body = preparedTestResults[i]?.statsPerTarget?.[targetIdx]?.responseBody || '';
 
-						if (_.shouldCollapseResponseBody(body, this.getRawOutputCharsPerLine())) {
+						if (_.shouldCollapseResponseBody(body, charsPerLine)) {
 							return true;
 						}
 					}
@@ -1980,7 +1988,7 @@
 					app.router.replaceQueryParam('order', sortOrder === DEFAULT_SORT_ORDER ? null : sortOrder, this);
 				});
 
-				this.observe('sortOrder sortBy preparedTestResults activeTargetIdx rawOutputMode', () => {
+				this.observe('sortOrder sortBy preparedTestResults activeTargetIdx', () => {
 					let sortOrder = this.get('sortOrder');
 					let sortBy = this.get('sortBy');
 					let preparedTestResults = this.get('preparedTestResults');
@@ -1988,8 +1996,18 @@
 					let activeTargetIdx = rawOutputMode ? this.get('activeTargetIdx') : 0;
 
 					if (preparedTestResults.length) {
-						this.set('preparedTestResults', _.sortGpMeasurementResults(preparedTestResults, sortBy, sortOrder, activeTargetIdx));
+						let sortedResults = _.sortGpMeasurementResults(preparedTestResults, sortBy, sortOrder, activeTargetIdx);
+						let orderChanged = sortedResults.length !== preparedTestResults.length
+							|| sortedResults.some((result, idx) => result.clientSideId !== preparedTestResults[idx]?.clientSideId);
+
+						if (orderChanged) {
+							this.set('preparedTestResults', sortedResults);
+						}
 					}
+				});
+
+				this.observe('preparedTestResults rawOutputMode testInProgress', () => {
+					this.scheduleTablePreparedTestResultsUpdate();
 				});
 
 				// clear table sort params and enable rawOutputMode whenever test type isn't ping
@@ -2388,6 +2406,10 @@
 
 					let testType = this.get('testReqParams.type');
 					let isInfiniteModeRes = this.get('isInfiniteModeRes');
+					let sortBy = this.get('sortBy');
+					let sortOrder = this.get('sortOrder');
+					let rawOutputMode = this.get('rawOutputMode');
+					let activeTargetIdx = rawOutputMode ? this.get('activeTargetIdx') : 0;
 					let preparedTestResults;
 
 					if (testType === 'ping' && isInfiniteModeRes) {
@@ -2395,6 +2417,8 @@
 					} else {
 						preparedTestResults = this.prepareRegularResults(testResults);
 					}
+
+					preparedTestResults = _.sortGpMeasurementResults(preparedTestResults, sortBy, sortOrder, activeTargetIdx);
 
 					this.set('preparedTestResults', preparedTestResults);
 				});
@@ -2509,11 +2533,60 @@
 			}
 
 			clearTimeout(this.get('runTestBtnDelayTimeout'));
+			clearTimeout(this.tableResultsUpdateTimeout);
 			this.get('testReqCancelFn')?.forEach(cancel => cancel?.());
 			this.set('testReqCancelFn', []);
 		},
 		isActiveTestRun (testRunId) {
 			return testRunId === null || testRunId === undefined || testRunId === this.get('activeTestRunId');
+		},
+		updateTablePreparedTestResults () {
+			let preparedTestResults = this.get('preparedTestResults') || [];
+
+			this.set('tablePreparedTestResults', preparedTestResults);
+			this.lastTableResultsUpdate = performance.now();
+		},
+		isTableResultsShapeReady (preparedTestResults = this.get('tablePreparedTestResults') || []) {
+			let expectedTargetsCnt = this.get('targetsArr.length');
+
+			if (!this.get('isInfiniteModeRes') && this.get('qsMeasurementIdsArr.length') > 1) {
+				expectedTargetsCnt = this.get('qsMeasurementIdsArr.length');
+			}
+
+			let actualTargetsCnt = preparedTestResults[0]?.statsPerTarget?.length || 0;
+
+			return !expectedTargetsCnt || actualTargetsCnt >= expectedTargetsCnt;
+		},
+		scheduleTablePreparedTestResultsUpdate () {
+			if (this.get('rawOutputMode')) {
+				clearTimeout(this.tableResultsUpdateTimeout);
+				this.tableResultsUpdateTimeout = null;
+				return;
+			}
+
+			let preparedTestResults = this.get('preparedTestResults') || [];
+			let tablePreparedTestResults = this.get('tablePreparedTestResults') || [];
+			let hasRenderedResults = tablePreparedTestResults.length && this.isTableResultsShapeReady(tablePreparedTestResults);
+
+			if (!preparedTestResults.length || !this.get('testInProgress') || !hasRenderedResults) {
+				clearTimeout(this.tableResultsUpdateTimeout);
+				this.tableResultsUpdateTimeout = null;
+
+				this.updateTablePreparedTestResults();
+				return;
+			}
+
+			if (this.tableResultsUpdateTimeout) {
+				return;
+			}
+
+			let elapsed = performance.now() - (this.lastTableResultsUpdate || 0);
+			let delay = Math.max(TABLE_RESULTS_UPDATE_INTERVAL - elapsed, 0);
+
+			this.tableResultsUpdateTimeout = setTimeout(() => {
+				this.tableResultsUpdateTimeout = null;
+				this.updateTablePreparedTestResults();
+			}, delay);
 		},
 		handleRunTestBtn () {
 			if (this.get('runTestBtnDisabled')) {
@@ -3079,18 +3152,27 @@
 			this.set('responseBodyCharWidth', width > 0 ? width : 7);
 		},
 		getRawOutputCharsPerLine () {
-			let listEl = this.find('.c-gp-results-raw-output_list');
-			let listWidth = listEl?.getBoundingClientRect?.().width || 0;
+			let listEl;
 			let outputHorizontalPadding = 32 * 2;
 			let outputListMargin = 24 * 2;
+			let windowWidth = window.innerWidth;
+			let FALLBACK_CHAR_WIDTH = 7;
+
+			try {
+				listEl = this.find('.c-gp-results-raw-output_list');
+			} catch {
+				let contentWidth = Math.min(1240, windowWidth - outputListMargin - outputHorizontalPadding);
+				return Math.floor(contentWidth / FALLBACK_CHAR_WIDTH);
+			}
+
+			let listWidth = listEl?.getBoundingClientRect?.().width || 0;
 			let contentWidth = Math.max(1, listWidth - outputHorizontalPadding);
 
 			if (!listWidth) {
-				let windowWidth = window.innerWidth;
 				contentWidth = Math.min(1240, windowWidth - outputListMargin - outputHorizontalPadding);
 			}
 
-			let charWidth = this.get('responseBodyCharWidth') || 7;
+			let charWidth = this.get('responseBodyCharWidth') || FALLBACK_CHAR_WIDTH;
 			return Math.max(1, Math.floor(contentWidth / charWidth));
 		},
 		collapseAllRawOutput ({ responseBodyOnly = false } = {}) {

--- a/src/views/pages/_index.html
+++ b/src/views/pages/_index.html
@@ -1994,7 +1994,7 @@
 					app.router.replaceQueryParam('order', sortOrder === DEFAULT_SORT_ORDER ? null : sortOrder, this);
 				});
 
-				this.observe('sortOrder sortBy preparedTestResults activeTargetIdx', () => {
+				this.observe('sortOrder sortBy preparedTestResults activeTargetIdx rawOutputMode', () => {
 					let sortOrder = this.get('sortOrder');
 					let sortBy = this.get('sortBy');
 					let preparedTestResults = this.get('preparedTestResults');


### PR DESCRIPTION
Closes #170 

### Changes

- Avoid setting preparedTestResults after sorting if sorting did not result in any change
- Table rendering waits until the expected target shape is ready.
- Avoided unnecessary raw-output collapse work in table mode.
- Avoided repeated set-location find() calls when the floating button is inactive.
- (unrelated) added missing alt attributes

###  Impact

Loading a 500-probe, 2-target measurement:
> ~9s -> ~3s

Switching from table output to raw output:
> ~15s -> ~1s

Switching from raw output to table output:
> ~1.5s -> ~1s

Running a 500-probe, 2-target measurement:
> up to 120s -> real time updates, delay < 2s